### PR TITLE
Add clusterrole to allow access to operator APIs

### DIFF
--- a/tests/e2e-rh-sdl/rapidast-jaeger/01-assert.yaml
+++ b/tests/e2e-rh-sdl/rapidast-jaeger/01-assert.yaml
@@ -17,3 +17,17 @@ subjects:
 - kind: ServiceAccount
   name: privileged-sa
   namespace: rapidast-jaeger
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-jaeger-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-jaeger

--- a/tests/e2e-rh-sdl/rapidast-jaeger/01-create-sa.yaml
+++ b/tests/e2e-rh-sdl/rapidast-jaeger/01-create-sa.yaml
@@ -17,3 +17,17 @@ subjects:
 - kind: ServiceAccount
   name: privileged-sa
   namespace: rapidast-jaeger
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-jaeger-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-jaeger

--- a/tests/e2e-rh-sdl/rapidast-otel/01-assert.yaml
+++ b/tests/e2e-rh-sdl/rapidast-otel/01-assert.yaml
@@ -17,3 +17,17 @@ subjects:
 - kind: ServiceAccount
   name: privileged-sa
   namespace: rapidast-otel
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-otel-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-otel

--- a/tests/e2e-rh-sdl/rapidast-otel/01-create-sa.yaml
+++ b/tests/e2e-rh-sdl/rapidast-otel/01-create-sa.yaml
@@ -17,3 +17,17 @@ subjects:
 - kind: ServiceAccount
   name: privileged-sa
   namespace: rapidast-otel
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-otel-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-otel

--- a/tests/e2e-rh-sdl/rapidast-tempo/01-assert.yaml
+++ b/tests/e2e-rh-sdl/rapidast-tempo/01-assert.yaml
@@ -17,3 +17,17 @@ subjects:
 - kind: ServiceAccount
   name: privileged-sa
   namespace: rapidast-tempo
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-tempo-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-tempo

--- a/tests/e2e-rh-sdl/rapidast-tempo/01-create-sa.yaml
+++ b/tests/e2e-rh-sdl/rapidast-tempo/01-create-sa.yaml
@@ -17,3 +17,17 @@ subjects:
 - kind: ServiceAccount
   name: privileged-sa
   namespace: rapidast-tempo
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-tempo-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-tempo


### PR DESCRIPTION
This fixes RapiDAST scans returning empty results and allows the service account to access the operator API. 