### PR TITLE
Add test case for OTEL journald receiver

### DIFF
--- a/tests/e2e-otel/journaldreceiver/00-assert.yaml
+++ b/tests/e2e-otel/journaldreceiver/00-assert.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-journald.otel-joural-logs
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: otel-joural-logs-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: otel-joural-logs-collector
+  namespace: kuttl-journald
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: kuttl-journald.otel-joural-logs
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/instance: kuttl-journald.otel-joural-logs
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: otel-joural-logs-collector
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - args:
+        - --config=/conf/collector.yaml
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        name: otc-container
+        ports:
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - FSETID
+            - KILL
+            - NET_BIND_SERVICE
+            - SETGID
+            - SETPCAP
+            - SETUID
+          readOnlyRootFilesystem: true
+          seLinuxOptions:
+            type: spc_t
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /conf
+          name: otc-internal
+        - mountPath: /var/log/journal/
+          name: journal-logs
+          readOnly: true
+      serviceAccount: privileged-sa
+      serviceAccountName: privileged-sa
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: collector.yaml
+            path: collector.yaml
+          name: otel-joural-logs-collector
+        name: otc-internal
+      - hostPath:
+          path: /var/log/journal
+          type: ""
+        name: journal-logs
+
+---
+---
+# This KUTTL assert uses the check-daemonset.sh script to ensure the number of ready pods in a daemonset matches the desired count, retrying until successful or a timeout occurs. The script is needed as the number of Kubernetes cluster nodes can vary and we cannot statically set desiredNumberScheduled and numberReady in the assert for daemonset status. 
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: ./tests/e2e-otel/journaldreceiver/check_daemonset.sh
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-journald.otel-joural-logs
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: otel-joural-logs-collector-monitoring
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: otel-joural-logs-collector-monitoring
+  namespace: kuttl-journald
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-journald.otel-joural-logs
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry

--- a/tests/e2e-otel/journaldreceiver/00-otel-journaldreceiver.yaml
+++ b/tests/e2e-otel/journaldreceiver/00-otel-journaldreceiver.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuttl-journald
+  labels:
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: privileged-sa
+  namespace: kuttl-journald
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuttl-journald--binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: kuttl-journald
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-joural-logs
+  namespace: kuttl-journald
+spec:
+  mode: daemonset
+  serviceAccount: privileged-sa
+  serviceAccountName: privileged-sa
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - FSETID
+      - KILL
+      - NET_BIND_SERVICE
+      - SETGID
+      - SETPCAP
+      - SETUID
+    readOnlyRootFilesystem: true
+    seLinuxOptions:
+      type: spc_t
+    seccompProfile:
+      type: RuntimeDefault
+  image: quay.io/rhn_support_ikanse/otel-collector:latest
+  config: |
+    receivers:
+      journald:
+        files: /var/log/journal/*/*
+    processors:
+    exporters:
+      logging:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [journald]
+          processors: []
+          exporters: [logging]
+  volumeMounts:
+  - name: journal-logs
+    mountPath: /var/log/journal/
+    readOnly: true
+  volumes:
+  - name: journal-logs
+    type: ""
+    hostPath:
+      path: /var/log/journal
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule

--- a/tests/e2e-otel/journaldreceiver/01-assert.yaml
+++ b/tests/e2e-otel/journaldreceiver/01-assert.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- script: ./tests/e2e-otel/journaldreceiver/check_logs.sh

--- a/tests/e2e-otel/journaldreceiver/check_daemonset.sh
+++ b/tests/e2e-otel/journaldreceiver/check_daemonset.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Name of the daemonset to check
+DAEMONSET_NAME="otel-joural-logs-collector"
+NAMESPACE=kuttl-journald
+
+# Get the desired and ready pod counts for the daemonset
+read DESIRED READY <<< $(kubectl get daemonset -n $NAMESPACE $DAEMONSET_NAME -o custom-columns=:status.desiredNumberScheduled,:status.numberReady --no-headers)
+
+# Check if the desired count matches the ready count
+if [ "$DESIRED" -eq "$READY" ]; then
+  echo "Desired count ($DESIRED) matches the ready count ($READY) for $DAEMONSET_NAME."
+else
+  echo "Desired count ($DESIRED) does not match the ready count ($READY) for $DAEMONSET_NAME."
+  exit 1
+fi

--- a/tests/e2e-otel/journaldreceiver/check_logs.sh
+++ b/tests/e2e-otel/journaldreceiver/check_logs.sh
@@ -1,0 +1,61 @@
+
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=kuttl-journald
+
+# Define the search strings
+SEARCH_STRING1='_SYSTEMD_UNIT'
+SEARCH_STRING2='_UID'
+SEARCH_STRING3='_HOSTNAME'
+SEARCH_STRING4='_SYSTEMD_INVOCATION_ID'
+SEARCH_STRING5='_SELINUX_CONTEXT'
+
+# Get the list of pods with the specified label
+PODS=$(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}')
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+FOUND5=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in $PODS; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+    # Search for the fifth string
+    if ! $FOUND5 && kubectl -n $NAMESPACE --tail=100 logs $POD | grep -q -- "$SEARCH_STRING5"; then
+        echo "\"$SEARCH_STRING5\" found in $POD"
+        FOUND5=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4 || ! $FOUND5; then
+    echo "No journal logs found in otel-joural-logs-collector  collector"
+    exit 1
+else
+    echo "Found journal logs in otel-joural-logs-collector in collector."
+fi


### PR DESCRIPTION
```
ikanse@ikanse-mac distributed-tracing-qe % kuttl test --timeout=180 --test=journaldreceiver tests/e2e-otel
2024/01/25 15:00:00 running without a 'kuttl-test.yaml' configuration
2024/01/25 15:00:00 kutt-test config testdirs is overridden with args: [ tests/e2e-otel ]
=== RUN   kuttl
    harness.go:462: starting setup
    harness.go:252: running tests using configured kubeconfig.
    harness.go:275: Successful connection to cluster at: https://api.ikanse-46.qe.devcluster.openshift.com:6443
    harness.go:360: running tests
    harness.go:73: going to run test suite with timeout of 180 seconds for each step
    harness.go:372: testsuite: tests/e2e-otel has 2 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/journaldreceiver
=== PAUSE kuttl/harness/journaldreceiver
=== CONT  kuttl/harness/journaldreceiver
    logger.go:42: 15:00:04 | journaldreceiver | Ignoring check_daemonset.sh as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 15:00:04 | journaldreceiver | Ignoring check_logs.sh as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 15:00:04 | journaldreceiver | Creating namespace: kuttl-test-pleased-guinea
    logger.go:42: 15:00:04 | journaldreceiver/0-otel-journaldreceiver | starting test step 0-otel-journaldreceiver
    logger.go:42: 15:00:05 | journaldreceiver/0-otel-journaldreceiver | Namespace:/kuttl-journald created
    logger.go:42: 15:00:06 | journaldreceiver/0-otel-journaldreceiver | ServiceAccount:kuttl-journald/privileged-sa created
    logger.go:42: 15:00:07 | journaldreceiver/0-otel-journaldreceiver | ClusterRoleBinding:/kuttl-journald--binding updated
    logger.go:42: 15:00:07 | journaldreceiver/0-otel-journaldreceiver | OpenTelemetryCollector:kuttl-journald/otel-joural-logs created
    logger.go:42: 15:00:08 | journaldreceiver/0-otel-journaldreceiver | running command: [sh -c ./tests/e2e-otel/journaldreceiver/check_daemonset.sh]
    logger.go:42: 15:00:09 | journaldreceiver/0-otel-journaldreceiver | Desired count (6) does not match the ready count (1) for otel-joural-logs-collector.
    logger.go:42: 15:00:10 | journaldreceiver/0-otel-journaldreceiver | running command: [sh -c ./tests/e2e-otel/journaldreceiver/check_daemonset.sh]
    logger.go:42: 15:00:11 | journaldreceiver/0-otel-journaldreceiver | Desired count (6) matches the ready count (6) for otel-joural-logs-collector.
    logger.go:42: 15:00:11 | journaldreceiver/0-otel-journaldreceiver | test step completed 0-otel-journaldreceiver
    logger.go:42: 15:00:11 | journaldreceiver/1- | starting test step 1-
    logger.go:42: 15:00:12 | journaldreceiver/1- | running command: [sh -c ./tests/e2e-otel/journaldreceiver/check_logs.sh]
    logger.go:42: 15:00:15 | journaldreceiver/1- | "_SYSTEMD_UNIT" found in otel-joural-logs-collector-bxr4x
    logger.go:42: 15:00:16 | journaldreceiver/1- | "_UID" found in otel-joural-logs-collector-bxr4x
    logger.go:42: 15:00:17 | journaldreceiver/1- | "_HOSTNAME" found in otel-joural-logs-collector-bxr4x
    logger.go:42: 15:00:19 | journaldreceiver/1- | "_SYSTEMD_INVOCATION_ID" found in otel-joural-logs-collector-bxr4x
    logger.go:42: 15:00:20 | journaldreceiver/1- | "_SELINUX_CONTEXT" found in otel-joural-logs-collector-bxr4x
    logger.go:42: 15:00:20 | journaldreceiver/1- | Found journal logs in otel-joural-logs-collector in collector.
    logger.go:42: 15:00:20 | journaldreceiver/1- | test step completed 1-
    logger.go:42: 15:00:20 | journaldreceiver | journaldreceiver events from ns kuttl-test-pleased-guinea:
    logger.go:42: 15:00:21 | journaldreceiver | Deleting namespace: kuttl-test-pleased-guinea
=== CONT  kuttl
    harness.go:405: run tests finished
    harness.go:513: cleaning up
    harness.go:570: removing temp folder: ""
--- PASS: kuttl (28.42s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/journaldreceiver (24.60s)
PASS
```