### PR TITLE
Add test case for kubestatsreceiver

### DIFF
--- a/tests/e2e-otel/filelog/00-otel-filelog.yaml
+++ b/tests/e2e-otel/filelog/00-otel-filelog.yaml
@@ -28,6 +28,7 @@ metadata:
   name: otel-logs-sidecar
 spec:
   mode: sidecar
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.98.0
   config: |
     receivers:
       filelog:

--- a/tests/e2e-otel/journaldreceiver/00-otel-journaldreceiver.yaml
+++ b/tests/e2e-otel/journaldreceiver/00-otel-journaldreceiver.yaml
@@ -37,6 +37,7 @@ metadata:
   namespace: chainsaw-journald
 spec:
   mode: daemonset
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.98.0
   serviceAccount: privileged-sa
   serviceAccountName: privileged-sa
   securityContext:

--- a/tests/e2e-otel/kubeletstatsreceiver/chainsaw-test.yaml
+++ b/tests/e2e-otel/kubeletstatsreceiver/chainsaw-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kubeletstatsreceiver
+spec:
+  steps:
+  - name: Create OTEL collector with kubeletstats receiver
+    try:
+    - apply:
+        file: otel-kubeletstatsreceiver.yaml
+    - assert:
+        file: otel-kubeletstatsreceiver-assert.yaml
+  - name: Wait for the metrics to be collected
+    try:
+    - sleep:
+        duration: 60s
+  - name: Check some of the metrics in the OTEl collector
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh 

--- a/tests/e2e-otel/kubeletstatsreceiver/check_logs.sh
+++ b/tests/e2e-otel/kubeletstatsreceiver/check_logs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This script checks the OpenTelemetry collector pod for the presence of Logs.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-kubeletstatsreceiver
+
+# Define the search strings
+SEARCH_STRING1='k8s.pod.uid'
+SEARCH_STRING2='k8s.pod.name'
+SEARCH_STRING3='k8s.namespace.name'
+SEARCH_STRING4='k8s.container.name'
+
+# Get the list of pods with the specified label
+PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+FOUND3=false
+FOUND4=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in "${PODS[@]}"; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+    # Search for the third string
+    if ! $FOUND3 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING3"; then
+        echo "\"$SEARCH_STRING3\" found in $POD"
+        FOUND3=true
+    fi
+    # Search for the fourth string
+    if ! $FOUND4 && kubectl -n $NAMESPACE --tail=200 logs $POD | grep -q -- "$SEARCH_STRING4"; then
+        echo "\"$SEARCH_STRING4\" found in $POD"
+        FOUND4=true
+    fi
+done
+
+# Check if any of the strings was not found
+if ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4; then
+    echo "No Node metrics found in OpenTelemetry collector"
+    exit 1
+else
+    echo "Found all the Node metrics in OpenTelemetry collector."
+fi

--- a/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver-assert.yaml
+++ b/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver-assert.yaml
@@ -1,0 +1,64 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+status:
+  phase: Active
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+  namespace: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-kubeletstatsreceiver-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/stats
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-kubeletstatsreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-kubeletstatsreceiver-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-kubeletstatsreceiver
+  namespace: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chainsaw-kubeletstatsreceiver-collector
+  namespace: chainsaw-kubeletstatsreceiver
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  numberMisscheduled: 0
+  (desiredNumberScheduled == numberReady): true

--- a/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver.yaml
+++ b/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+  namespace: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-kubeletstatsreceiver-role
+rules:
+  - apiGroups: ['']
+    resources: ['nodes/stats']
+    verbs: ['get', 'watch', 'list']
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-kubeletstatsreceiver-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-kubeletstatsreceiver-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-kubeletstatsreceiver
+    namespace: chainsaw-kubeletstatsreceiver
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-kubeletstatsreceiver
+  namespace: chainsaw-kubeletstatsreceiver
+spec:
+  mode: daemonset
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.98.0
+  serviceAccount: chainsaw-kubeletstatsreceiver
+  serviceAccountName: chainsaw-kubeletstatsreceiver
+  env:
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  config: |
+    receivers:
+      kubeletstats:
+        collection_interval: 20s
+        auth_type: "serviceAccount"
+        endpoint: "https://${env:K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [kubeletstats]
+          exporters: [debug]
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule


### PR DESCRIPTION
The PR adds test case for OTEL kubestats receiver.
Completes:
https://issues.redhat.com/browse/TRACING-4162 