### PR TITLE
Update OTel collector to 0.148.0 and telemetrygen to v0.150.0

### DIFF
--- a/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/otel-collector-rolearn.yaml
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/otel-collector-rolearn.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otelcol-cloudwatch
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: otelcol-cloudwatch
   volumes:
     - name: aws-iam-token

--- a/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/otel-filelog-sidecar.yaml
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/otel-filelog-sidecar.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-logs-sidecar-rolearn-direct
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: sidecar
   config:
     receivers:

--- a/tests/e2e-otel/awscloudwatchlogs-rolearn/otel-collector-rolearn.yaml
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn/otel-collector-rolearn.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otelcol-cloudwatch
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: otelcol-cloudwatch
   env:
     - name: AWS_REGION

--- a/tests/e2e-otel/awscloudwatchlogs-rolearn/otel-filelog-sidecar.yaml
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn/otel-filelog-sidecar.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otel-logs-sidecar-rolearn
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config:
     receivers:
       filelog:

--- a/tests/e2e-otel/awscloudwatchlogsexporter/generate-metrics.yaml
+++ b/tests/e2e-otel/awscloudwatchlogsexporter/generate-metrics.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: telemetrygen-metrics
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=cwlogs-collector:4317"

--- a/tests/e2e-otel/awscloudwatchlogsexporter/otel-collector.yaml
+++ b/tests/e2e-otel/awscloudwatchlogsexporter/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: cwlogs
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   env:
     - name: AWS_ACCESS_KEY_ID
       valueFrom:

--- a/tests/e2e-otel/awscloudwatchlogsexporter/otel-filelog-sidecar.yaml
+++ b/tests/e2e-otel/awscloudwatchlogsexporter/otel-filelog-sidecar.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otel-logs-sidecar
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config:
     receivers:
       filelog:

--- a/tests/e2e-otel/awsxrayexporter/otel-collector.yaml
+++ b/tests/e2e-otel/awsxrayexporter/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: xray
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   env:
     - name: AWS_ACCESS_KEY_ID
       valueFrom:

--- a/tests/e2e-otel/countconnector/check_metrics.sh
+++ b/tests/e2e-otel/countconnector/check_metrics.sh
@@ -10,9 +10,9 @@ THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o jso
 metrics=("dev_log_count_total{telemetrygentype=\"logs\"}" \
          "dev_metrics_datapoint_total{telemetrygentype=\"metrics\"}" \
          "dev_span_count_total{telemetrygentype=\"traces\"}" \
-         "metric_count_total{telemetrygentype=\"metrics\"}")
+         "dev_metric_count_total")
 
-values=(1 1 10 1)
+values=(5 5 10 5)
 
 # Check metrics for OpenTelemetry collector instance.
 for i in "${!metrics[@]}"; do

--- a/tests/e2e-otel/countconnector/generate-telemetry-data.yaml
+++ b/tests/e2e-otel/countconnector/generate-telemetry-data.yaml
@@ -32,13 +32,14 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=count-collector:4317
         - --otlp-insecure=true
         - --traces=5
-        - "--otlp-attributes=telemetrygentype=\"traces\""
+        - --rate=0
+        - "--telemetry-attributes=telemetrygentype=\"traces\""
       restartPolicy: Never
   backoffLimit: 4
 
@@ -52,13 +53,14 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - metrics
         - --otlp-endpoint=count-collector:4317
         - --otlp-insecure=true
         - --metrics=5
-        - "--otlp-attributes=telemetrygentype=\"metrics\""
+        - --rate=0
+        - "--telemetry-attributes=telemetrygentype=\"metrics\""
       restartPolicy: Never
   backoffLimit: 4
 
@@ -72,12 +74,13 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - logs
         - --otlp-endpoint=count-collector:4317
         - --otlp-insecure=true
         - --logs=5
-        - "--otlp-attributes=telemetrygentype=\"logs\""
+        - --rate=0
+        - "--telemetry-attributes=telemetrygentype=\"logs\""
       restartPolicy: Never
   backoffLimit: 4

--- a/tests/e2e-otel/countconnector/otel-collector.yaml
+++ b/tests/e2e-otel/countconnector/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: count
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   observability:
     metrics:
@@ -17,21 +17,27 @@ spec:
     processors: {}
     connectors:
       count:
-        logs:
-          dev.log.count:
-            description: The number of logs from each environment.
+        spans:
+          dev.span.count:
+            description: The number of spans from each environment.
             attributes:
               - key: telemetrygentype
                 default_value: unspecified_environment
+        spanevents:
+          dev.spanevent.count:
+            description: The number of span events from each environment.
+        metrics:
+          dev.metric.count:
+            description: The number of metrics from each environment.
         datapoints:
           dev.metrics.datapoint:
             description: The number of metric datapoints from each environment.
             attributes:
               - key: telemetrygentype
                 default_value: unspecified_environment
-        spans:
-          dev.span.count:
-            description: The number of spans from each environment.
+        logs:
+          dev.log.count:
+            description: The number of logs from each environment.
             attributes:
               - key: telemetrygentype
                 default_value: unspecified_environment

--- a/tests/e2e-otel/filelog/otel-collector.yaml
+++ b/tests/e2e-otel/filelog/otel-collector.yaml
@@ -33,7 +33,7 @@ metadata:
   name: clusterlogs
   namespace: chainsaw-filelog
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: daemonset
   config:
     receivers:

--- a/tests/e2e-otel/filestorageext/otel-filestorageext.yaml
+++ b/tests/e2e-otel/filestorageext/otel-filestorageext.yaml
@@ -28,7 +28,7 @@ metadata:
   name: filestorageext-sidecar
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config: |
     receivers:
       filelog:

--- a/tests/e2e-otel/filterprocessor/generate-telemetry-data.yaml
+++ b/tests/e2e-otel/filterprocessor/generate-telemetry-data.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: traces-red
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=filterprocessor-collector:4318"
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: traces-green
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=filterprocessor-collector:4318"
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: metrics-red
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=filterprocessor-collector:4318"
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: metrics-green
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=filterprocessor-collector:4318"
@@ -126,7 +126,7 @@ spec:
     spec:
       containers:
         - name: logs-red
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=filterprocessor-collector:4318"
@@ -155,7 +155,7 @@ spec:
     spec:
       containers:
         - name: logs-green
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=filterprocessor-collector:4318"

--- a/tests/e2e-otel/filterprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/filterprocessor/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: filterprocessor
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config:
     receivers:
       otlp:

--- a/tests/e2e-otel/forwardconnector/generate-traces.yaml
+++ b/tests/e2e-otel/forwardconnector/generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen-blue
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=otlp-forward-connector-collector:4318
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen-green
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=otlp-forward-connector-collector:4319

--- a/tests/e2e-otel/forwardconnector/otel-forward-connector.yaml
+++ b/tests/e2e-otel/forwardconnector/otel-forward-connector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otlp-forward-connector
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config: |
     receivers:
       otlp/blue:

--- a/tests/e2e-otel/googlecloudexporter/otel-collector.yaml
+++ b/tests/e2e-otel/googlecloudexporter/otel-collector.yaml
@@ -34,7 +34,7 @@ metadata:
   name: googlecloudexporter
   namespace: chainsaw-googlecloudexporter
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-googlecloudexporter-sa
   # Mount the Google WIF credential file and expose the credential path as env var
   env:

--- a/tests/e2e-otel/googlecloudexporter/telemetry-generator.yaml
+++ b/tests/e2e-otel/googlecloudexporter/telemetry-generator.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=googlecloudexporter-collector:4317
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - metrics
         - --otlp-endpoint=googlecloudexporter-collector:4317
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - logs
         - --otlp-endpoint=googlecloudexporter-collector:4317

--- a/tests/e2e-otel/googlemanagedprometheus/gcp-sa/metrics-generator-app.yaml
+++ b/tests/e2e-otel/googlemanagedprometheus/gcp-sa/metrics-generator-app.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: metrics
-          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0'
+          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0'
           args: ["metrics", "--otlp-insecure", "--rate=0.1", "--duration=5m", "--otlp-endpoint=$(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)"]
           imagePullPolicy: IfNotPresent
           env:

--- a/tests/e2e-otel/googlemanagedprometheus/gcp-sa/metrics-generator-kubeletstats.yaml
+++ b/tests/e2e-otel/googlemanagedprometheus/gcp-sa/metrics-generator-kubeletstats.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: chainsaw-kubeletstatsreceiver
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-kubeletstatsreceiver
   env:
   - name: K8S_NODE_NAME

--- a/tests/e2e-otel/googlemanagedprometheus/gcp-wif/metrics-generator-app.yaml
+++ b/tests/e2e-otel/googlemanagedprometheus/gcp-wif/metrics-generator-app.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: metrics
-          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0'
+          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0'
           args: ["metrics", "--otlp-insecure", "--rate=0.1", "--duration=5m", "--otlp-endpoint=$(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)"]
           imagePullPolicy: IfNotPresent
           env:

--- a/tests/e2e-otel/googlemanagedprometheus/gcp-wif/metrics-generator-kubeletstats.yaml
+++ b/tests/e2e-otel/googlemanagedprometheus/gcp-wif/metrics-generator-kubeletstats.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: chainsaw-kubeletstatsreceiver
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-kubeletstatsreceiver
   env:
   - name: K8S_NODE_NAME

--- a/tests/e2e-otel/groupbyattrsprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/otel-collector.yaml
@@ -39,7 +39,7 @@ metadata:
   namespace: chainsaw-gba
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-gba
   env:
   - name: K8S_NODE_NAME

--- a/tests/e2e-otel/groupbyattrsprocessor/otel-groupbyattributes.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/otel-groupbyattributes.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: chainsaw-gba
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   observability:
     metrics:
       enableMetrics: true

--- a/tests/e2e-otel/hostmetricsreceiver/otel-hostmetricsreceiver.yaml
+++ b/tests/e2e-otel/hostmetricsreceiver/otel-hostmetricsreceiver.yaml
@@ -44,7 +44,7 @@ metadata:
   name: otel-hstmtrs
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: otel-hostfs-daemonset
   config: |
     receivers:

--- a/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver.yaml
+++ b/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver.yaml
@@ -103,7 +103,7 @@ metadata:
   namespace: chainsaw-k8sclusterreceiver
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-k8sclusterreceiver
   config: |
     receivers:

--- a/tests/e2e-otel/k8seventsreceiver/otel-k8seventsreceiver.yaml
+++ b/tests/e2e-otel/k8seventsreceiver/otel-k8seventsreceiver.yaml
@@ -103,7 +103,7 @@ metadata:
   namespace: chainsaw-k8seventsreceiver
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-k8seventsreceiver
   config: |
     receivers:

--- a/tests/e2e-otel/k8sobjectsreceiver/otel-k8sobjectsreceiver.yaml
+++ b/tests/e2e-otel/k8sobjectsreceiver/otel-k8sobjectsreceiver.yaml
@@ -56,7 +56,7 @@ metadata:
   namespace: chainsaw-k8sobjectsreceiver
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-k8sobjectsreceiver
   config: |
     receivers:

--- a/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver.yaml
+++ b/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: chainsaw-kubeletstatsreceiver
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-kubeletstatsreceiver
   env:
   - name: K8S_NODE_NAME

--- a/tests/e2e-otel/loadbalancingexporter/generate-traces.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen-blue
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=chainsaw-lb-collector:4318
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen-green
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=chainsaw-lb-collector:4318
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen-red
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=chainsaw-lb-collector:4318

--- a/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-lb.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-lb.yaml
@@ -50,7 +50,7 @@ metadata:
   name: chainsaw-lb
   namespace: chainsaw-lb
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   serviceAccount: chainsaw-lb
   config: |
     receivers:

--- a/tests/e2e-otel/oidcauthextension/generate-traces.yaml
+++ b/tests/e2e-otel/oidcauthextension/generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=chainsaw-oidc-client-collector:4317

--- a/tests/e2e-otel/oidcauthextension/install-otel-oidc-client.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-otel-oidc-client.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: chainsaw-oidc-client
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   volumes:
     - name: chainsaw-certs

--- a/tests/e2e-otel/oidcauthextension/install-otel-oidc-server.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-otel-oidc-server.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: chainsaw-oidc-server
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   volumeMounts:
   - mountPath: /certs

--- a/tests/e2e-otel/otlpjsonfilereceiver/fileexporter-otel-collector.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/fileexporter-otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: fileexporter
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config: |
     receivers:
       otlp:

--- a/tests/e2e-otel/otlpjsonfilereceiver/generate-traces.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=fileexporter-collector:4317

--- a/tests/e2e-otel/otlpjsonfilereceiver/otlpjsonfilereceiver-otel-collector.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/otlpjsonfilereceiver-otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otlpjsonfile
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config: |
     receivers:
       otlpjsonfile:

--- a/tests/e2e-otel/probabilisticsamplerprocessor/generate-traces-hash-seed.yaml
+++ b/tests/e2e-otel/probabilisticsamplerprocessor/generate-traces-hash-seed.yaml
@@ -13,7 +13,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-otel/probabilisticsamplerprocessor/generate-traces-proportional.yaml
+++ b/tests/e2e-otel/probabilisticsamplerprocessor/generate-traces-proportional.yaml
@@ -13,7 +13,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-otel/probabilisticsamplerprocessor/otel-collector-hash-seed.yaml
+++ b/tests/e2e-otel/probabilisticsamplerprocessor/otel-collector-hash-seed.yaml
@@ -4,7 +4,7 @@ metadata:
   name: probabilistic-hash-seed
   namespace: chainsaw-probabilistic-sampler
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   config:
     receivers:

--- a/tests/e2e-otel/probabilisticsamplerprocessor/otel-collector-proportional.yaml
+++ b/tests/e2e-otel/probabilisticsamplerprocessor/otel-collector-proportional.yaml
@@ -4,7 +4,7 @@ metadata:
   name: probabilistic-proportional
   namespace: chainsaw-probabilistic-sampler
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   config:
     receivers:

--- a/tests/e2e-otel/profilesignal/otel-collector.yaml
+++ b/tests/e2e-otel/profilesignal/otel-collector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otel-profiles-collector
   namespace: chainsaw-profilesignal
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   args:
     feature-gates: service.profilesSupport

--- a/tests/e2e-otel/prometheusremotewriteexporter/generate-metrics.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/generate-metrics.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: telemetrygen-metrics
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=otel-collector:4317"

--- a/tests/e2e-otel/prometheusremotewriteexporter/otel-collector.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/otel-collector.yaml
@@ -20,7 +20,7 @@ spec:
     - name: certs-volume
       secret:
         secretName: prometheus-ca
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   config: |
     receivers:

--- a/tests/e2e-otel/prometheusremotewritereceiver/README.md
+++ b/tests/e2e-otel/prometheusremotewritereceiver/README.md
@@ -73,7 +73,7 @@ The test follows this sequence as defined in [`chainsaw-test.yaml`](./chainsaw-t
 ### Sender Collector Prometheus Remote Write (v2) Configuration:
 - **Target Endpoint**: `http://otel-receiver-collector:9090/api/v1/write`
 - **Protocol**: Prometheus Remote Write v2 (enabled via feature gate + v2 protobuf)
-- **Collector Image**: `opentelemetry-collector-contrib:0.147.0`
+- **Collector Image**: `opentelemetry-collector-contrib:0.148.0`
 
 ### Simplified Architecture:
 ```

--- a/tests/e2e-otel/prometheusremotewritereceiver/generate-metrics.yaml
+++ b/tests/e2e-otel/prometheusremotewritereceiver/generate-metrics.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: telemetrygen-metrics
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
           command: ["./telemetrygen"]
           args:
             - "--otlp-endpoint=otel-sender-collector:4317"

--- a/tests/e2e-otel/prometheusremotewritereceiver/otel-collector-receiver.yaml
+++ b/tests/e2e-otel/prometheusremotewritereceiver/otel-collector-receiver.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-receiver
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   config: |
     receivers:

--- a/tests/e2e-otel/prometheusremotewritereceiver/otel-collector-sender.yaml
+++ b/tests/e2e-otel/prometheusremotewritereceiver/otel-collector-sender.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-sender
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   mode: deployment
   args:
     feature-gates: exporter.prometheusremotewritexporter.enableSendingRW2

--- a/tests/e2e-otel/routingconnector/generate-traces.yaml
+++ b/tests/e2e-otel/routingconnector/generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=routing-collector.chainsaw-routecnctr.svc:4317
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=routing-collector.chainsaw-routecnctr.svc:4317
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=routing-collector.chainsaw-routecnctr.svc:4317

--- a/tests/e2e-otel/routingconnector/otel-collector.yaml
+++ b/tests/e2e-otel/routingconnector/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: routing
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config:
     receivers:
       otlp:

--- a/tests/e2e-otel/tailsamplingprocessor/generate-traces.yaml
+++ b/tests/e2e-otel/tailsamplingprocessor/generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=tailsmp-collector:4317

--- a/tests/e2e-otel/tailsamplingprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/tailsamplingprocessor/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: tailsmp
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config:
     receivers:
       otlp:

--- a/tests/e2e-otel/transformprocessor/generate-traces.yaml
+++ b/tests/e2e-otel/transformprocessor/generate-traces.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: telemetrygen
-        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.129.0
+        image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.150.0
         args:
         - traces
         - --otlp-endpoint=tprocssr-collector.chainsaw-tprocssr.svc:4317

--- a/tests/e2e-otel/transformprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/transformprocessor/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: tprocssr
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.147.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
   config:
     receivers:
       otlp:
@@ -28,9 +28,9 @@ spec:
               - truncate_all(attributes, 4096)
           - context: span
             statements:
-              - set(attributes["net.peer.ip"], "5.6.7.8") where attributes["net.sock.peer.addr"] == "1.2.3.4"
-              - set(attributes["peer.service"], "modified-server") where attributes["peer.service"] == "telemetrygen-server"
-              - set(attributes["peer.service"], "modified-client") where attributes["peer.service"] == "telemetrygen-client"
+              - set(attributes["net.peer.ip"], "5.6.7.8") where attributes["network.peer.address"] == "1.2.3.4"
+              - set(attributes["peer.service"], "modified-server") where attributes["service.peer.name"] == "telemetrygen-server"
+              - set(attributes["peer.service"], "modified-client") where attributes["service.peer.name"] == "telemetrygen-client"
               - set(name, "modified-operation") where name == "okey-dokey-0"
               - limit(attributes, 100, [])
               - truncate_all(attributes, 4096)


### PR DESCRIPTION
## Summary
- Update OpenTelemetry collector-contrib image from 0.147.0 to 0.148.0 across all e2e-otel tests (37 files)
- Update telemetrygen image from v0.129.0 to v0.150.0 across all e2e-otel tests (17 files)
- Fix transformprocessor test: update transform WHERE conditions to match telemetrygen v0.150.0 semantic convention changes (`net.sock.peer.addr` → `network.peer.address`, `peer.service` → `service.peer.name`)
- Fix countconnector test: align with count connector documentation by using `--telemetry-attributes` for data item attributes, adding all five documented sections (`spans`, `spanevents`, `metrics`, `datapoints`, `logs`), correcting expected metric values, and using `--rate=0` to batch all items in a single request

## Test plan
- [x] `chainsaw test --test-dir tests/e2e-otel/transformprocessor` — PASS
- [x] `chainsaw test --test-dir tests/e2e-otel/countconnector` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)