### PR TITLE
Add Claude Code CLI standalone binary to Dockerfile used by OCP CI and Konflux.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,16 @@ RUN mkdir -p /tmp/go/bin $GOCACHE \
 # Install dependencies required by test cases and debugging
 RUN apt-get update && apt-get install -y jq vim libreadline-dev unzip
 
+# Install Claude Code CLI via signed apt repository
+RUN install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://downloads.claude.ai/keys/claude-code.asc \
+         -o /etc/apt/keyrings/claude-code.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/claude-code.asc] https://downloads.claude.ai/claude-code/apt/stable stable main" \
+         > /etc/apt/sources.list.d/claude-code.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends claude-code \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install chainsaw
 RUN curl -L -o chainsaw.tar.gz https://github.com/kyverno/chainsaw/releases/download/v0.2.13/chainsaw_linux_amd64.tar.gz \
     && tar -xvzf chainsaw.tar.gz \

--- a/Dockerfile-konflux
+++ b/Dockerfile-konflux
@@ -70,5 +70,11 @@ RUN echo "Install operator-sdk and dependencies" \
     && chmod +x /usr/local/bin/operator-sdk \
     && operator-sdk version
 
+# Install Claude Code CLI via signed dnf repository
+RUN printf '[claude-code]\nname=Claude Code\nbaseurl=https://downloads.claude.ai/claude-code/rpm/stable\nenabled=1\ngpgcheck=1\ngpgkey=https://downloads.claude.ai/keys/claude-code.asc\n' \
+         > /etc/yum.repos.d/claude-code.repo \
+    && dnf install -y claude-code \
+    && dnf clean all && rm -rf /var/cache/dnf
+
 # Add gcloud to PATH
 ENV PATH="/tmp/google-cloud-sdk/bin:${PATH}"


### PR DESCRIPTION
## Summary

- Adds Claude Code CLI to `Dockerfile` (apt) and `Dockerfile-konflux` (dnf) using Anthropic's official signed package repositories
- `Dockerfile` (Debian/golang base): registers the signed apt repo at `https://downloads.claude.ai/claude-code/apt/stable` and installs the `claude-code` package
- `Dockerfile-konflux` (RHEL/ose-cli base): registers the signed dnf repo at `https://downloads.claude.ai/claude-code/rpm/stable` and installs the `claude-code` package
- Package manager installation ensures GPG signature verification is handled natively by apt/dnf — no manual key import or hardcoded checksums required
- The `claude` binary is installed to `/usr/bin/claude` and is globally accessible

## Test plan

- [x] `Dockerfile` built successfully with `podman build --platform=linux/amd64`
- [x] `Dockerfile-konflux` built successfully with `podman build --platform=linux/amd64`
- [x] `claude --version` confirmed working in both images (`2.1.153 (Claude Code)`)
- [x] Binary available at `/usr/bin/claude` in both images

🤖 Generated with [Claude Code](https://claude.com/claude-code)