### PR TITLE
TRACING-6381: Fix OTEL k8scluster receiver RBAC

### DIFF
--- a/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver-assert.yaml
+++ b/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver-assert.yaml
@@ -29,6 +29,8 @@ rules:
   - namespaces/status
   - nodes
   - nodes/spec
+  - persistentvolumeclaims
+  - persistentvolumes
   - pods
   - pods/status
   - replicationcontrollers

--- a/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver.yaml
+++ b/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver.yaml
@@ -24,6 +24,8 @@ rules:
   - namespaces/status
   - nodes
   - nodes/spec
+  - persistentvolumeclaims
+  - persistentvolumes
   - pods
   - pods/status
   - replicationcontrollers


### PR DESCRIPTION
https://redhat.atlassian.net/browse/TRACING-6381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Kubernetes cluster receiver test configurations to enable monitoring of persistent volumes and persistent volume claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->