### PR TITLE
Improve cleanup of orphaned OCP CI resources in GCP

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,175 @@
+# hack/cleanup-gcp-resources.py
+
+Deletes orphaned GCP resources created by OpenShift CI jobs (`ci-op` prefix) that are older than a configurable age threshold (default: 6 hours). Designed to supplement the DPP team's automated pruning, which misses certain resource types.
+
+## Prerequisites
+
+### 1. Python 3.9 or later
+
+```bash
+python3 --version   # must be 3.9+
+```
+
+### 2. Google Cloud SDK (`gcloud`)
+
+Install from the [official docs](https://cloud.google.com/sdk/docs/install) or via a package manager:
+
+```bash
+# macOS
+brew install google-cloud-sdk
+
+# Verify
+gcloud --version
+```
+
+### 3. Authentication
+
+Authenticate as a user with sufficient permissions:
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+```
+
+Or point to a service account key file:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+```
+
+### 4. GCP IAM Permissions
+
+The principal (user or service account) running the script needs the following roles on the target project, or equivalent custom permissions:
+
+| Role | Purpose |
+|------|---------|
+| `roles/compute.admin` | List and delete Compute Engine resources (instances, disks, networks, firewall rules, load balancer components, etc.) |
+| `roles/dns.admin` | List and delete Cloud DNS managed zones and record sets |
+| `roles/storage.admin` | List and delete Cloud Storage buckets and their contents |
+| `roles/iam.serviceAccountAdmin` | List and delete IAM service accounts |
+| `roles/iam.serviceAccountKeyAdmin` | List service account keys (used as a creation-time proxy) |
+
+To verify your current permissions:
+
+```bash
+gcloud projects get-iam-policy openshift-observability \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:$(gcloud config get-value account)"
+```
+
+### 5. Active Project
+
+Confirm access to the target project:
+
+```bash
+gcloud projects describe openshift-observability
+```
+
+## Usage
+
+Always run from the repository root.
+
+```bash
+# Dry run — print what would be deleted without touching anything
+python3 hack/cleanup-gcp-resources.py --project openshift-observability --dry-run
+
+# Live run with default 6-hour age threshold
+python3 hack/cleanup-gcp-resources.py --project openshift-observability
+
+# Tighten the threshold to 4 hours
+python3 hack/cleanup-gcp-resources.py --project openshift-observability --max-age-hours 4
+
+# Enable verbose output (prints every gcloud command)
+python3 hack/cleanup-gcp-resources.py --project openshift-observability --debug
+```
+
+The project can also be set via an environment variable:
+
+```bash
+export GCP_PROJECT=openshift-observability
+python3 hack/cleanup-gcp-resources.py --dry-run
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | `$GCP_PROJECT` | GCP project ID (required if env var not set) |
+| `--dry-run` | off | Print planned deletions without executing them |
+| `--max-age-hours N` | `6` | Skip resources newer than N hours (minimum 1) |
+| `--debug` | off | Enable DEBUG-level logging (every gcloud call printed) |
+
+## Resource Types Covered
+
+The script deletes resources in dependency order to avoid deletion failures. Each stage must complete before the next begins.
+
+| Step | Resource type | Scope | Notes |
+|------|--------------|-------|-------|
+| 1 | ForwardingRule | global + regional | Must precede TargetTcpProxy |
+| 2 | TargetTcpProxy | global | External API load balancer proxy |
+| 3 | BackendService | global + regional | After TCP proxy is released |
+| 4 | HealthCheck | global + regional | After BackendService |
+| 5 | Address | global + regional | Freed after ForwardingRule is gone |
+| 6 | DNS ManagedZone | global | Non-NS/SOA records deleted first |
+| 7 | Storage Bucket | global | Recursive deletion of contents |
+| 8 | FirewallRule | global | |
+| 9 | ManagedInstanceGroup | zonal + regional | Auto-deletes its worker instances |
+| 10 | ComputeInstance | zonal | Master nodes, bastion, remaining workers |
+| 11 | Disk | zonal + regional | Orphaned boot disks |
+| 12 | InstanceTemplate | global | Worker templates (after MIGs) |
+| 13 | UnmanagedInstanceGroup | zonal | Master instance groups (now empty) |
+| 14 | Router | regional | Cloud NAT must be removed before Subnetwork |
+| 15 | Subnetwork | regional | After all instances and routers are gone |
+| 16 | Network | global | After all subnets are deleted |
+| 17 | IAM ServiceAccount | global | Age proxied via oldest user-managed key |
+
+### Service Account age proxy
+
+GCP does not expose a creation timestamp for service accounts. The script uses the `validAfterTime` of the oldest user-managed key as an age proxy. Service accounts with no user-managed keys (worker and master compute SAs that authenticate via GCE instance metadata) are always skipped to avoid deleting credentials for a potentially live cluster.
+
+## How It Selects Resources
+
+A resource is targeted for deletion only when **both** conditions are true:
+
+1. **Name prefix**: the resource name starts with `ci-op` (the OpenShift CI job prefix).
+2. **Age**: the resource's creation timestamp is older than `--max-age-hours`.
+
+Resources that fail either check are logged as `Skip` and counted in the `skipped` total.
+
+## Output and Exit Codes
+
+The script logs one line per resource:
+
+```
+[INFO] Skip ci-op-<id>-apiserver    (newer than 6h)
+[INFO] Deleting ForwardingRule/global/ci-op-<id>-apiserver
+[WARN] Already gone ForwardingRule/… (resource not found — likely cleaned by CI)
+[ERROR] FAILED to delete BackendService/… : <error excerpt>
+```
+
+Final summary line:
+
+```
+Done — deleted=6  skipped=219  warnings=0  errors=0
+```
+
+| Counter | Meaning |
+|---------|---------|
+| `deleted` | Resources successfully removed (or would-be in dry-run) |
+| `skipped` | Resources excluded by name or age filter |
+| `warnings` | Resources already gone before the script reached them (normal in shared CI) |
+| `errors` | Real deletion failures that need investigation |
+
+**Exit code 0** when `errors == 0`; **exit code 1** otherwise.
+
+## Running in CI
+
+For automated/non-interactive execution, authenticate via a service account key:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json
+export GCP_PROJECT=openshift-observability
+python3 hack/cleanup-gcp-resources.py
+```
+
+The script never prompts for input and is safe to run concurrently with OpenShift CI jobs. Concurrent cleanup races are handled gracefully — "resource not found" responses are counted as `warnings`, not `errors`.

--- a/hack/README.md
+++ b/hack/README.md
@@ -140,7 +140,7 @@ Resources that fail either check are logged as `Skip` and counted in the `skippe
 
 The script logs one line per resource:
 
-```
+```text
 [INFO] Skip ci-op-<id>-apiserver    (newer than 6h)
 [INFO] Deleting ForwardingRule/global/ci-op-<id>-apiserver
 [WARN] Already gone ForwardingRule/… (resource not found — likely cleaned by CI)
@@ -149,7 +149,7 @@ The script logs one line per resource:
 
 Final summary line:
 
-```
+```text
 Done — deleted=6  skipped=219  warnings=0  errors=0
 ```
 

--- a/hack/cleanup-gcp-resources.py
+++ b/hack/cleanup-gcp-resources.py
@@ -7,10 +7,23 @@ older than --max-age-hours (default: 6). Follows the dependency order
 required to avoid deletion failures.
 
 Deletion sequence:
-  1. TargetTcpProxy → BackendService (global) → HealthCheck
-  2. DNS ManagedZone  (non-NS/SOA record sets first, then the zone)
-  3. Storage Buckets
-  4. FirewallRule → InstanceGroup → Subnetwork → Network
+   1. ForwardingRule (global + regional)   — must precede TargetTcpProxy
+   2. TargetTcpProxy                       — global only (OpenShift IPI)
+   3. BackendService (global + regional)   — after TCP proxy is released
+   4. HealthCheck (global + regional)
+   5. Address (global + regional)          — freed after ForwardingRule is gone
+   6. DNS ManagedZone  (non-NS/SOA record sets first, then the zone)
+   7. Storage Buckets
+   8. FirewallRule
+   9. ManagedInstanceGroup (zonal + regional) — auto-deletes worker instances
+  10. ComputeInstance (zonal)              — master, bastion, remaining workers
+  11. Disk (zonal + regional)             — orphaned boot disks
+  12. InstanceTemplate (global)           — worker templates
+  13. UnmanagedInstanceGroup (zonal)      — master groups, now empty
+  14. Router (regional)                   — Cloud NAT must go before Subnetwork
+  15. Subnetwork (regional)
+  16. Network (global)
+  17. IAM ServiceAccount  (age proxy: oldest user-managed key creation time)
 
 Usage:
   # See what would be deleted without touching anything
@@ -40,6 +53,17 @@ from datetime import datetime, timedelta, timezone
 CI_NAME_PREFIX = "ci-op"
 DEFAULT_MAX_AGE_HOURS = 6
 
+# Phrases that gcloud emits when a resource no longer exists.  These races are
+# normal in a shared CI environment where CI jobs clean up their own resources
+# concurrently.  We treat them as warnings, not errors.
+_NOT_FOUND_PHRASES = frozenset([
+    "was not found",
+    "does not exist",
+    "not found",
+    "resource not found",
+    "no such",
+])
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -52,24 +76,32 @@ log = logging.getLogger(__name__)
 # Low-level helpers
 # ---------------------------------------------------------------------------
 
-def _run(cmd: list[str]) -> tuple[str, int]:
-    """Run *cmd* and return (stdout, returncode). Never raises."""
+def _run(cmd: list[str]) -> tuple[str, str, int]:
+    """Run *cmd* and return (stdout, stderr, returncode). Never raises."""
     log.debug("+ %s", " ".join(cmd))
     try:
         result = subprocess.run(cmd, capture_output=True, text=True)
     except FileNotFoundError:
         log.error("Command not found: %s — is gcloud installed and on PATH?", cmd[0])
-        return "", 127
+        return "", "", 127
     if result.returncode != 0:
         log.debug("stderr: %s", result.stderr.strip())
-    return result.stdout.strip(), result.returncode
+    return result.stdout.strip(), result.stderr.strip(), result.returncode
 
 
-def gcloud_list(*args, project: str) -> list[dict]:
-    """Run a `gcloud … list` command and return the parsed JSON array."""
-    cmd = ["gcloud", *args, "--format=json", "--quiet", "--project", project]
-    stdout, rc = _run(cmd)
-    if rc != 0 or not stdout:
+def gcloud_list(*args, project: str, fmt: str = "json") -> list[dict]:
+    """Run a `gcloud … list` command and return the parsed JSON array.
+
+    *fmt* defaults to ``json`` but can be overridden with a gcloud format
+    projection (e.g. ``json(name,timeCreated)``) to request specific fields
+    that are not included in the default output.
+    """
+    cmd = ["gcloud", *args, f"--format={fmt}", "--quiet", "--project", project]
+    stdout, _stderr, rc = _run(cmd)
+    if rc != 0:
+        log.warning("gcloud list failed (rc=%d): %s", rc, _stderr.splitlines()[0] if _stderr else "(no output)")
+        return []
+    if not stdout:
         return []
     try:
         return json.loads(stdout)
@@ -120,6 +152,7 @@ class GCPCleaner:
         self.max_age_hours = max_age_hours
         self.deleted = 0
         self.skipped = 0
+        self.warnings = 0
         self.errors = 0
 
     # -- eligibility ---------------------------------------------------------
@@ -145,21 +178,55 @@ class GCPCleaner:
         Pass include_project=False for commands (e.g. gcloud storage rm) that
         do not accept the --project flag.
         """
-        full_cmd = [*cmd, "--quiet", *( ["--project", self.project] if include_project else [])]
+        full_cmd = [*cmd, "--quiet", *(["--project", self.project] if include_project else [])]
         if self.dry_run:
             log.info("[DRY-RUN] Would delete %s", label)
             self.deleted += 1
             return True
         log.info("Deleting %s", label)
-        _, rc = _run(full_cmd)
+        _, stderr, rc = _run(full_cmd)
         if rc != 0:
-            log.error("FAILED to delete %s", label)
+            stderr_lower = stderr.lower()
+            if any(phrase in stderr_lower for phrase in _NOT_FOUND_PHRASES):
+                # Resource was already deleted (by CI cleanup or a concurrent run).
+                # This is normal in a shared environment — treat as a benign warning.
+                log.warning("Already gone %s (resource not found — likely cleaned by CI)", label)
+                self.warnings += 1
+                return True
+            excerpt = stderr[:300].replace("\n", " | ") if stderr else "(no message)"
+            log.error("FAILED to delete %s: %s", label, excerpt)
             self.errors += 1
             return False
         self.deleted += 1
         return True
 
     # -- resource handlers (called in dependency order) ----------------------
+
+    def clean_forwarding_rules(self) -> None:
+        log.info("=== ForwardingRule (global) ===")
+        for item in gcloud_list("compute", "forwarding-rules", "list", "--global",
+                                project=self.project):
+            name = item.get("name", "")
+            if self._eligible(name, item.get("creationTimestamp")):
+                self._delete(
+                    f"ForwardingRule/global/{name}",
+                    ["gcloud", "compute", "forwarding-rules", "delete", name, "--global"],
+                )
+
+        log.info("=== ForwardingRule (regional) ===")
+        for item in gcloud_list("compute", "forwarding-rules", "list", project=self.project):
+            if item.get("region") is None:
+                continue
+            name = item.get("name", "")
+            region = url_last_segment(item.get("region", ""))
+            if not region:
+                log.warning("ForwardingRule %s has no region, skipping", name)
+                continue
+            if self._eligible(name, item.get("creationTimestamp")):
+                self._delete(
+                    f"ForwardingRule/{region}/{name}",
+                    ["gcloud", "compute", "forwarding-rules", "delete", name, "--region", region],
+                )
 
     def clean_target_tcp_proxies(self) -> None:
         log.info("=== TargetTcpProxy ===")
@@ -209,6 +276,32 @@ class GCPCleaner:
                     ["gcloud", "compute", "health-checks", "delete", name],
                 )
 
+    def clean_addresses(self) -> None:
+        log.info("=== Address (global) ===")
+        for item in gcloud_list("compute", "addresses", "list", "--global",
+                                project=self.project):
+            name = item.get("name", "")
+            if self._eligible(name, item.get("creationTimestamp")):
+                self._delete(
+                    f"Address/global/{name}",
+                    ["gcloud", "compute", "addresses", "delete", name, "--global"],
+                )
+
+        log.info("=== Address (regional) ===")
+        for item in gcloud_list("compute", "addresses", "list", project=self.project):
+            if item.get("region") is None:
+                continue
+            name = item.get("name", "")
+            region = url_last_segment(item.get("region", ""))
+            if not region:
+                log.warning("Address %s has no region, skipping", name)
+                continue
+            if self._eligible(name, item.get("creationTimestamp")):
+                self._delete(
+                    f"Address/{region}/{name}",
+                    ["gcloud", "compute", "addresses", "delete", name, "--region", region],
+                )
+
     def clean_dns_zones(self) -> None:
         log.info("=== DNS ManagedZone ===")
         for zone in gcloud_list("dns", "managed-zones", "list", project=self.project):
@@ -245,11 +338,17 @@ class GCPCleaner:
 
     def clean_storage_buckets(self) -> None:
         log.info("=== Storage Bucket ===")
-        for item in gcloud_list("storage", "buckets", "list", project=self.project):
-            # gcloud may return the name as "gs://bucket-name" or just "bucket-name"
-            raw = item.get("name", "")
-            name = raw.removeprefix("gs://").rstrip("/")
-            ts = item.get("timeCreated") or item.get("createTime")
+        # gcloud storage uses snake_case: creation_time, NOT timeCreated.
+        # Request it explicitly since it is absent from the default projection.
+        items = gcloud_list(
+            "storage", "buckets", "list",
+            project=self.project,
+            fmt="json(name,creation_time)",
+        )
+        for item in items:
+            # Strip gs:// prefix defensively; modern gcloud returns bare names.
+            name = item.get("name", "").removeprefix("gs://")
+            ts = item.get("creation_time")
             if not self._eligible(name, ts):
                 continue
             # gcloud storage rm does not accept --project; pass include_project=False.
@@ -269,22 +368,79 @@ class GCPCleaner:
                     ["gcloud", "compute", "firewall-rules", "delete", name],
                 )
 
-    def clean_instance_groups(self) -> None:
+    def clean_managed_instance_groups(self) -> None:
         log.info("=== InstanceGroup (managed) ===")
-        for item in gcloud_list("compute", "instance-groups", "managed", "list", project=self.project):
+        for item in gcloud_list("compute", "instance-groups", "managed", "list",
+                                project=self.project):
             name = item.get("name", "")
             zone = url_last_segment(item.get("zone", ""))
-            if not zone:
-                log.warning("ManagedInstanceGroup %s has no zone, skipping", name)
+            region = url_last_segment(item.get("region", ""))
+            if zone:
+                scope_flag = ["--zone", zone]
+                label = f"ManagedInstanceGroup/{zone}/{name}"
+            elif region:
+                scope_flag = ["--region", region]
+                label = f"ManagedInstanceGroup/{region}/{name}"
+            else:
+                log.warning("ManagedInstanceGroup %s has no zone or region, skipping", name)
                 continue
             if self._eligible(name, item.get("creationTimestamp")):
                 self._delete(
-                    f"ManagedInstanceGroup/{zone}/{name}",
-                    ["gcloud", "compute", "instance-groups", "managed", "delete", name, "--zone", zone],
+                    label,
+                    ["gcloud", "compute", "instance-groups", "managed", "delete",
+                     name, *scope_flag],
                 )
 
+    def clean_compute_instances(self) -> None:
+        log.info("=== ComputeInstance ===")
+        for item in gcloud_list("compute", "instances", "list", project=self.project):
+            name = item.get("name", "")
+            zone = url_last_segment(item.get("zone", ""))
+            if not zone:
+                log.warning("ComputeInstance %s has no zone, skipping", name)
+                continue
+            if self._eligible(name, item.get("creationTimestamp")):
+                self._delete(
+                    f"ComputeInstance/{zone}/{name}",
+                    ["gcloud", "compute", "instances", "delete", name, "--zone", zone],
+                )
+
+    def clean_disks(self) -> None:
+        log.info("=== Disk ===")
+        for item in gcloud_list("compute", "disks", "list", project=self.project):
+            name = item.get("name", "")
+            zone = url_last_segment(item.get("zone", ""))
+            region = url_last_segment(item.get("region", ""))
+            if zone:
+                scope_flag = ["--zone", zone]
+                label = f"Disk/{zone}/{name}"
+            elif region:
+                scope_flag = ["--region", region]
+                label = f"Disk/{region}/{name}"
+            else:
+                log.warning("Disk %s has no zone or region, skipping", name)
+                continue
+            if self._eligible(name, item.get("creationTimestamp")):
+                self._delete(
+                    label,
+                    ["gcloud", "compute", "disks", "delete", name, *scope_flag],
+                )
+
+    def clean_instance_templates(self) -> None:
+        log.info("=== InstanceTemplate ===")
+        for item in gcloud_list("compute", "instance-templates", "list",
+                                project=self.project):
+            name = item.get("name", "")
+            if self._eligible(name, item.get("creationTimestamp")):
+                self._delete(
+                    f"InstanceTemplate/{name}",
+                    ["gcloud", "compute", "instance-templates", "delete", name],
+                )
+
+    def clean_unmanaged_instance_groups(self) -> None:
         log.info("=== InstanceGroup (unmanaged) ===")
-        for item in gcloud_list("compute", "instance-groups", "unmanaged", "list", project=self.project):
+        for item in gcloud_list("compute", "instance-groups", "unmanaged", "list",
+                                project=self.project):
             name = item.get("name", "")
             zone = url_last_segment(item.get("zone", ""))
             if not zone:
@@ -293,7 +449,8 @@ class GCPCleaner:
             if self._eligible(name, item.get("creationTimestamp")):
                 self._delete(
                     f"UnmanagedInstanceGroup/{zone}/{name}",
-                    ["gcloud", "compute", "instance-groups", "unmanaged", "delete", name, "--zone", zone],
+                    ["gcloud", "compute", "instance-groups", "unmanaged", "delete",
+                     name, "--zone", zone],
                 )
 
     def clean_subnetworks(self) -> None:
@@ -310,6 +467,20 @@ class GCPCleaner:
                     ["gcloud", "compute", "networks", "subnets", "delete", name, "--region", region],
                 )
 
+    def clean_routers(self) -> None:
+        log.info("=== Router ===")
+        for item in gcloud_list("compute", "routers", "list", project=self.project):
+            name = item.get("name", "")
+            region = url_last_segment(item.get("region", ""))
+            if not region:
+                log.warning("Router %s has no region, skipping", name)
+                continue
+            if self._eligible(name, item.get("creationTimestamp")):
+                self._delete(
+                    f"Router/{region}/{name}",
+                    ["gcloud", "compute", "routers", "delete", name, "--region", region],
+                )
+
     def clean_networks(self) -> None:
         log.info("=== Network ===")
         for item in gcloud_list("compute", "networks", "list", project=self.project):
@@ -323,6 +494,65 @@ class GCPCleaner:
                     ["gcloud", "compute", "networks", "delete", name],
                 )
 
+    def clean_service_accounts(self) -> None:
+        log.info("=== IAM ServiceAccount ===")
+        # Pre-filter at the API level to avoid fetching keys for every account.
+        accounts = gcloud_list(
+            "iam", "service-accounts", "list",
+            f"--filter=email:{CI_NAME_PREFIX}*",
+            project=self.project,
+        )
+        for item in accounts:
+            email = item.get("email", "")
+            if not is_ci_resource(email):
+                # Defense-in-depth: API filter uses a prefix glob; Python check
+                # ensures we never act on a non-CI account if the glob misfires.
+                continue
+            ts = self._oldest_sa_key_time(email)
+            if ts is None:
+                # Compute-node SAs (worker/master) authenticate via GCE instance
+                # metadata — they never have user-managed keys. We cannot
+                # distinguish an orphaned compute SA from one belonging to an
+                # active cluster without a creation timestamp, so we skip these
+                # rather than risk deleting credentials for a live cluster.
+                log.info("Skip %-55s  (no user-managed keys — compute SA, skipping)", email)
+                self.skipped += 1
+                continue
+            if not is_older_than(ts, self.max_age_hours):
+                log.info("Skip %-55s  (newer than %dh)", email, self.max_age_hours)
+                self.skipped += 1
+                continue
+            self._delete(
+                f"ServiceAccount/{email}",
+                ["gcloud", "iam", "service-accounts", "delete", email],
+            )
+
+    def _oldest_sa_key_time(self, email: str) -> str | None:
+        """Return the creation timestamp of the oldest user-managed key for *email*.
+
+        Returns None when no user-managed keys exist. The caller skips such
+        accounts: compute-node SAs (worker/master) authenticate via GCE instance
+        metadata and never have user-managed keys, so absence of keys does not
+        mean the account is unused or orphaned.
+
+        Limitation: if an old SA has had all of its keys rotated to new ones,
+        the oldest remaining key will appear recent and the SA will be skipped
+        until the new key ages past the threshold.
+        """
+        keys = gcloud_list(
+            "iam", "service-accounts", "keys", "list",
+            "--iam-account", email, "--managed-by=user",
+            project=self.project,
+        )
+        if not keys:
+            return None
+        times = [k.get("validAfterTime") for k in keys if k.get("validAfterTime")]
+        parsed = [parse_timestamp(t) for t in times if t]
+        valid = [t for t in parsed if t is not None]
+        if not valid:
+            return None
+        return min(valid).isoformat()
+
     # -- entry point ---------------------------------------------------------
 
     def run(self) -> bool:
@@ -332,19 +562,27 @@ class GCPCleaner:
         )
 
         # Dependency-ordered: each group must finish before the next starts.
+        self.clean_forwarding_rules()           # before TargetTcpProxy
         self.clean_target_tcp_proxies()
         self.clean_backend_services()
         self.clean_health_checks()
+        self.clean_addresses()                  # after ForwardingRule releases IPs
         self.clean_dns_zones()
         self.clean_storage_buckets()
         self.clean_firewall_rules()
-        self.clean_instance_groups()
+        self.clean_managed_instance_groups()    # auto-deletes worker instances
+        self.clean_compute_instances()          # master, bastion, remaining workers
+        self.clean_disks()                      # orphaned boot disks
+        self.clean_instance_templates()         # worker templates
+        self.clean_unmanaged_instance_groups()  # master groups, now empty
+        self.clean_routers()                    # Cloud NAT must precede Subnetwork
         self.clean_subnetworks()
         self.clean_networks()
+        self.clean_service_accounts()
 
         log.info(
-            "Done — deleted=%d  skipped=%d  errors=%d",
-            self.deleted, self.skipped, self.errors,
+            "Done — deleted=%d  skipped=%d  warnings=%d  errors=%d",
+            self.deleted, self.skipped, self.warnings, self.errors,
         )
         return self.errors == 0
 
@@ -373,7 +611,7 @@ def main() -> None:
         type=int,
         default=DEFAULT_MAX_AGE_HOURS,
         metavar="N",
-        help="Skip resources newer than N hours. Default: %(default)s",
+        help="Skip resources newer than N hours (must be ≥ 1). Default: %(default)s",
     )
     parser.add_argument(
         "--debug",
@@ -387,6 +625,8 @@ def main() -> None:
 
     if not args.project:
         parser.error("--project is required (or set the GCP_PROJECT environment variable)")
+    if args.max_age_hours < 1:
+        parser.error("--max-age-hours must be at least 1 (got %d)" % args.max_age_hours)
 
     cleaner = GCPCleaner(args.project, args.dry_run, args.max_age_hours)
     sys.exit(0 if cleaner.run() else 1)

--- a/hack/cleanup-gcp-resources.py
+++ b/hack/cleanup-gcp-resources.py
@@ -59,9 +59,7 @@ DEFAULT_MAX_AGE_HOURS = 6
 _NOT_FOUND_PHRASES = frozenset([
     "was not found",
     "does not exist",
-    "not found",
     "resource not found",
-    "no such",
 ])
 
 logging.basicConfig(
@@ -99,8 +97,9 @@ def gcloud_list(*args, project: str, fmt: str = "json") -> list[dict]:
     cmd = ["gcloud", *args, f"--format={fmt}", "--quiet", "--project", project]
     stdout, _stderr, rc = _run(cmd)
     if rc != 0:
-        log.warning("gcloud list failed (rc=%d): %s", rc, _stderr.splitlines()[0] if _stderr else "(no output)")
-        return []
+        msg = _stderr.splitlines()[0] if _stderr else "(no output)"
+        log.error("gcloud list failed (rc=%d): %s", rc, msg)
+        raise RuntimeError(f"gcloud list (rc={rc}): {msg}")
     if not stdout:
         return []
     try:
@@ -154,6 +153,16 @@ class GCPCleaner:
         self.skipped = 0
         self.warnings = 0
         self.errors = 0
+
+    # -- stage runner --------------------------------------------------------
+
+    def _run_clean(self, fn) -> None:
+        """Run a clean_* stage; catch list-API failures and record them as errors."""
+        try:
+            fn()
+        except RuntimeError as exc:
+            log.error("List operation failed, stage aborted: %s", exc)
+            self.errors += 1
 
     # -- eligibility ---------------------------------------------------------
 
@@ -321,7 +330,12 @@ class GCPCleaner:
 
     def _delete_dns_records(self, zone: str) -> bool:
         """Delete all non-NS/SOA records from *zone*. Returns True when all succeeded."""
-        records = gcloud_list("dns", "record-sets", "list", "--zone", zone, project=self.project)
+        try:
+            records = gcloud_list("dns", "record-sets", "list", "--zone", zone, project=self.project)
+        except RuntimeError as exc:
+            log.error("Failed to list DNS records for zone %s: %s", zone, exc)
+            self.errors += 1
+            return False
         all_ok = True
         for record in records:
             rtype = record.get("type", "")
@@ -539,11 +553,16 @@ class GCPCleaner:
         the oldest remaining key will appear recent and the SA will be skipped
         until the new key ages past the threshold.
         """
-        keys = gcloud_list(
-            "iam", "service-accounts", "keys", "list",
-            "--iam-account", email, "--managed-by=user",
-            project=self.project,
-        )
+        try:
+            keys = gcloud_list(
+                "iam", "service-accounts", "keys", "list",
+                "--iam-account", email, "--managed-by=user",
+                project=self.project,
+            )
+        except RuntimeError as exc:
+            log.error("Failed to list keys for SA %s: %s", email, exc)
+            self.errors += 1
+            return None
         if not keys:
             return None
         times = [k.get("validAfterTime") for k in keys if k.get("validAfterTime")]
@@ -562,23 +581,25 @@ class GCPCleaner:
         )
 
         # Dependency-ordered: each group must finish before the next starts.
-        self.clean_forwarding_rules()           # before TargetTcpProxy
-        self.clean_target_tcp_proxies()
-        self.clean_backend_services()
-        self.clean_health_checks()
-        self.clean_addresses()                  # after ForwardingRule releases IPs
-        self.clean_dns_zones()
-        self.clean_storage_buckets()
-        self.clean_firewall_rules()
-        self.clean_managed_instance_groups()    # auto-deletes worker instances
-        self.clean_compute_instances()          # master, bastion, remaining workers
-        self.clean_disks()                      # orphaned boot disks
-        self.clean_instance_templates()         # worker templates
-        self.clean_unmanaged_instance_groups()  # master groups, now empty
-        self.clean_routers()                    # Cloud NAT must precede Subnetwork
-        self.clean_subnetworks()
-        self.clean_networks()
-        self.clean_service_accounts()
+        # _run_clean catches RuntimeError from gcloud list failures so one bad
+        # stage does not abort subsequent independent stages.
+        self._run_clean(self.clean_forwarding_rules)           # before TargetTcpProxy
+        self._run_clean(self.clean_target_tcp_proxies)
+        self._run_clean(self.clean_backend_services)
+        self._run_clean(self.clean_health_checks)
+        self._run_clean(self.clean_addresses)                  # after ForwardingRule releases IPs
+        self._run_clean(self.clean_dns_zones)
+        self._run_clean(self.clean_storage_buckets)
+        self._run_clean(self.clean_firewall_rules)
+        self._run_clean(self.clean_managed_instance_groups)    # auto-deletes worker instances
+        self._run_clean(self.clean_compute_instances)          # master, bastion, remaining workers
+        self._run_clean(self.clean_disks)                      # orphaned boot disks
+        self._run_clean(self.clean_instance_templates)         # worker templates
+        self._run_clean(self.clean_unmanaged_instance_groups)  # master groups, now empty
+        self._run_clean(self.clean_routers)                    # Cloud NAT must precede Subnetwork
+        self._run_clean(self.clean_subnetworks)
+        self._run_clean(self.clean_networks)
+        self._run_clean(self.clean_service_accounts)
 
         log.info(
             "Done — deleted=%d  skipped=%d  warnings=%d  errors=%d",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the GCP resource cleanup utility, including prerequisites, CLI usage, flags, deletion workflow, and guidance for safe concurrent CI runs.

* **Improvements**
  * Improved cleanup correctness with an expanded, dependency-ordered deletion sequence and additional cleanup coverage (including regional/global addresses and regional routers).
  * Enhanced reliability of GCP operations by improving listing/command handling and treating “resource not found” as non-fatal warnings.
  * Added targeted removal of old user-managed ServiceAccount keys and tightened CLI validation for safer operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->