### PR TITLE
Add e2e test for Azure Monitor logs forwarding via OTel Collector

### DIFF
--- a/tests/e2e-otel/azuremonitorlogs/README.md
+++ b/tests/e2e-otel/azuremonitorlogs/README.md
@@ -1,0 +1,639 @@
+# OpenTelemetry Azure Monitor Logs Forwarding Test
+
+This test validates forwarding OpenShift cluster application logs to Azure Monitor via an OpenTelemetry Collector and ClusterLogForwarder (CLF). Logs flow from application pods through the Cluster Logging Operator (CLO) collectors, into an OTel Collector gateway, and are exported to Azure Monitor using OTLP over HTTP with OAuth2 authentication.
+
+## What This Test Does
+
+The test validates that:
+- Azure Monitor resources (Log Analytics workspace, DCE, DCR) can be provisioned via ARM template
+- An OTel Collector with `oauth2client` extension authenticates to Azure Monitor using a service principal
+- The `otlphttp` exporter sends logs to Azure Monitor's OTLP ingestion endpoint
+- A ClusterLogForwarder routes application logs to the OTel Collector via OTLP
+- Logs arrive in the Azure Monitor `OTelLogs` table and can be queried via KQL
+
+## Prerequisites
+
+- **Azure CLI** (`az`) logged in with permissions to create resource groups, workspaces, service principals, and DCR/DCE resources
+- **Azure subscription** set to the target subscription (e.g., `az account set --subscription <name>`)
+- **OpenShift cluster** with:
+  - OpenTelemetry Operator installed
+  - Cluster Logging Operator (CLO) 6.x installed
+  - `oc` CLI configured with cluster-admin access
+- **Chainsaw** test framework (for automated test execution)
+
+## Architecture
+
+```
++------------------+     +---------------------+     +---------------------+     +-------------------+
+| ocp-logtest      | --> | CLO Collector Pods   | --> | OTel Collector      | --> | Azure Monitor     |
+| (log generator)  |     | (openshift-logging)  |     | (otlphttp exporter) |     | (OTelLogs table)  |
++------------------+     +---------------------+     +---------------------+     +-------------------+
+  Writes to stdout         ClusterLogForwarder         oauth2client extension      DCE -> DCR ->
+  ~1 log/sec               routes application          authenticates via SP        Log Analytics
+  SVTLogger format         logs via OTLP               sends to Azure OTLP        Workspace
+                           to port 4318                ingestion endpoint
+```
+
+## Test Resources
+
+### 1. Azure Monitor Resource Provisioning
+- **File**: [`create-azure-monitor-resources.sh`](./create-azure-monitor-resources.sh)
+- **Purpose**: Creates all Azure resources needed for OTLP log ingestion
+- **Key Actions**:
+  - Creates resource group `otel-azure-monitor-logs` in `eastus`
+  - Creates Log Analytics workspace `otel-azm-logs`
+  - Deploys DCE and DCR via ARM template
+  - Creates service principal with `Monitoring Metrics Publisher` role on the DCR
+  - Stores credentials in a Kubernetes secret `azure-monitor-credentials`
+  - Stores test metadata in a ConfigMap `azure-monitor-test-config`
+
+### 2. ARM Template for DCE/DCR
+- **File**: [`dcr-arm-template.json`](./dcr-arm-template.json)
+- **Purpose**: Deploys Data Collection Endpoint (DCE) and Data Collection Rule (DCR)
+- **Key Features**:
+  - Uses API version `2024-03-11` with `directDataSources.otelLogs`
+  - Routes `Microsoft-OTel-Logs` stream to Log Analytics workspace
+  - Outputs DCR immutable ID, DCE logs ingestion endpoint, and DCR resource ID
+
+### 3. Azure Resource Cleanup
+- **File**: [`delete-azure-monitor-resources.sh`](./delete-azure-monitor-resources.sh)
+- **Purpose**: Tears down all Azure resources after the test
+- **Key Actions**: Deletes service principal, resource group (cascading to workspace/DCE/DCR), and Kubernetes secret/ConfigMap
+
+### 4. OpenTelemetry Collector
+- **File**: [`otel-collector.yaml`](./otel-collector.yaml)
+- **Contains**: OTel Collector CR (Deployment mode) with Azure Monitor exporter
+- **Key Features**:
+  - `oauth2client` extension for Azure AD authentication via service principal
+  - `otlp` receiver (HTTP port 4318, gRPC port 4317)
+  - `transform` processor to merge resource attributes into log attributes
+  - `memory_limiter` and `batch` processors
+  - `otlphttp/azure` exporter using `logs_endpoint` for full OTLP URL
+  - `debug` exporter for troubleshooting
+  - Uses the operator's default collector image (the `image` field can be uncommented to pin a specific version)
+
+### 5. OTel Collector Assertion
+- **File**: [`otel-collector-assert.yaml`](./otel-collector-assert.yaml)
+- **Purpose**: Asserts the collector Deployment has 1 ready replica and Service exposes ports 4317/4318
+
+### 6. ClusterLogForwarder Setup
+- **File**: [`setup-cluster-log-forwarder.sh`](./setup-cluster-log-forwarder.sh)
+- **Purpose**: Creates the logcollector SA, grants permissions, and deploys ClusterLogForwarder
+- **Key Actions**:
+  - Creates `logcollector` service account in `openshift-logging` namespace
+  - Grants `collect-application-logs` cluster role
+  - Creates CLF with OTLP output pointing to the OTel Collector service
+  - Requires `observability.openshift.io/tech-preview-otlp-output: "enabled"` annotation
+  - Waits for CLO collector pods to become ready
+
+### 7. ClusterLogForwarder Cleanup
+- **File**: [`cleanup-cluster-log-forwarder.sh`](./cleanup-cluster-log-forwarder.sh)
+- **Purpose**: Deletes the ClusterLogForwarder, cluster role bindings, and logcollector SA from `openshift-logging` namespace
+
+### 8. Log Generator Application
+- **File**: [`app-plaintext-logs.yaml`](./app-plaintext-logs.yaml)
+- **Contains**: ConfigMap and ReplicationController for log generation
+- **Key Features**:
+  - Uses `ocp-logtest` image that writes `SVTLogger` lines to stdout at ~1 log/sec
+  - Runs as non-root user (UID 1000) with restricted security context
+
+### 9. Log Generator Assertion
+- **File**: [`app-plaintext-logs-assert.yaml`](./app-plaintext-logs-assert.yaml)
+- **Purpose**: Asserts the ReplicationController has 1 available/ready replica
+
+### 10. Azure Monitor Verification
+- **File**: [`check_azure_logs.sh`](./check_azure_logs.sh)
+- **Purpose**: Queries Azure Monitor to verify logs arrived
+- **Key Features**:
+  - Reads workspace customer ID from ConfigMap
+  - Checks collector pod logs for export errors
+  - Queries `OTelLogs` table via KQL: `OTelLogs | where Body has 'SVTLogger' | take 10`
+  - Retries up to 25 times with 30-second intervals (~12 minutes)
+
+### 11. Chainsaw Test Definition
+- **File**: [`chainsaw-test.yaml`](./chainsaw-test.yaml)
+- **Contains**: Complete test workflow with 5 steps and cleanup handlers
+
+## Test Steps
+
+The test follows this sequence as defined in [`chainsaw-test.yaml`](./chainsaw-test.yaml):
+
+1. **Create Azure Monitor resources and credentials** - Run [`create-azure-monitor-resources.sh`](./create-azure-monitor-resources.sh) (cleanup: [`delete-azure-monitor-resources.sh`](./delete-azure-monitor-resources.sh))
+2. **Deploy OTel Collector with Azure Monitor exporter** - Apply [`otel-collector.yaml`](./otel-collector.yaml), assert readiness
+3. **Grant log collector permissions and deploy ClusterLogForwarder** - Run [`setup-cluster-log-forwarder.sh`](./setup-cluster-log-forwarder.sh) (cleanup: [`cleanup-cluster-log-forwarder.sh`](./cleanup-cluster-log-forwarder.sh))
+4. **Deploy log generator application** - Annotate namespace for SCC, apply [`app-plaintext-logs.yaml`](./app-plaintext-logs.yaml), assert readiness
+5. **Verify logs are received in Azure Monitor** - Run [`check_azure_logs.sh`](./check_azure_logs.sh)
+
+## Verification
+
+The [`check_azure_logs.sh`](./check_azure_logs.sh) script validates:
+- The OTel Collector pod has no export errors
+- The Azure Monitor `OTelLogs` table contains log entries with `SVTLogger` in the `Body` column
+- Returns the first matching log entry as a sample, showing attributes like `k8s.namespace.name`, `k8s.pod.name`, and `openshift.log.type`
+
+## Cleanup
+
+The test automatically cleans up:
+- **Azure resources**: Service principal, resource group (cascading to workspace, DCE, DCR), Kubernetes secret and ConfigMap
+- **Cluster resources**: ClusterLogForwarder, logcollector SA, and cluster role bindings in `openshift-logging`; log generator pods and OTel Collector in the test namespace
+- **Namespace**: Chainsaw deletes the test namespace automatically
+
+## Key Configuration Notes
+
+- **Service account ordering**: The `logcollector` SA must be created *before* applying the ClusterLogForwarder. CLO 6.x does not create it automatically.
+- **Table name**: Logs land in `OTelLogs` (not `OTLPLogs`). Use this table name in KQL queries.
+- **OAuth2 scope**: Use `https://monitor.azure.com/.default` (single slash, not double `//`).
+- **Exporter endpoint**: Use `logs_endpoint` (full URL including `/v1/logs`) instead of `endpoint` (which appends `/v1/logs` automatically). The full URL format is: `https://<dce-domain>/dataCollectionRules/<dcr-immutable-id>/streams/Microsoft-OTLP-Logs/otlp/v1/logs`
+- **OTLP output annotation**: The CLF requires the tech-preview annotation `observability.openshift.io/tech-preview-otlp-output: "enabled"` for OTLP output type.
+- **SCC annotations**: The test namespace needs `openshift.io/sa.scc.uid-range=1000/1000` and `openshift.io/sa.scc.supplemental-groups=3000/1000` for the log generator to run.
+- **Workspace soft-delete**: Azure retains deleted Log Analytics workspaces for 14 days. The create script purges any soft-deleted workspace to avoid stale table state.
+- **Ingestion latency**: Azure Monitor typically takes 3-8 minutes to ingest OTLP data into the `OTelLogs` table.
+
+## Running the Automated Test
+
+```bash
+export KUBECONFIG=/path/to/kubeconfig
+az login
+az account set --subscription "<subscription-name>"
+chainsaw test --test-dir tests/e2e-otel/azuremonitorlogs --no-color
+```
+
+---
+
+## Manual Setup Guide
+
+This section provides step-by-step instructions to manually set up the complete log forwarding pipeline from an OpenShift cluster to Azure Monitor via an OpenTelemetry Collector.
+
+### Step 1: Log in to Azure and Set Subscription
+
+```bash
+az login
+az account set --subscription "<your-subscription-name>"
+az account show --query "{name:name, id:id}" -o table
+```
+
+### Step 2: Create a Resource Group
+
+```bash
+LOCATION="eastus"
+RG_NAME="otel-azure-monitor-logs"
+
+az group create --name "$RG_NAME" --location "$LOCATION" --output none
+```
+
+### Step 3: Create a Log Analytics Workspace
+
+```bash
+WORKSPACE_NAME="otel-azm-logs"
+
+az monitor log-analytics workspace create \
+    --resource-group "$RG_NAME" \
+    --workspace-name "$WORKSPACE_NAME" \
+    --location "$LOCATION" \
+    --output none
+
+# Capture workspace IDs for later use
+WORKSPACE_RESOURCE_ID=$(az monitor log-analytics workspace show \
+    --resource-group "$RG_NAME" \
+    --workspace-name "$WORKSPACE_NAME" \
+    --query "id" -o tsv)
+
+WORKSPACE_CUSTOMER_ID=$(az monitor log-analytics workspace show \
+    --resource-group "$RG_NAME" \
+    --workspace-name "$WORKSPACE_NAME" \
+    --query "customerId" -o tsv)
+
+echo "Workspace Resource ID: $WORKSPACE_RESOURCE_ID"
+echo "Workspace Customer ID: $WORKSPACE_CUSTOMER_ID"
+```
+
+### Step 4: Deploy Data Collection Endpoint and Rule
+
+Save the following ARM template as `dcr-arm-template.json`:
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": { "type": "string" },
+    "logAnalyticsWorkspaceResourceId": { "type": "string" },
+    "dataCollectionEndpointName": { "type": "string", "defaultValue": "otel-azm-dce" },
+    "dataCollectionRuleName": { "type": "string", "defaultValue": "otel-azm-dcr" }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionEndpoints",
+      "apiVersion": "2024-03-11",
+      "name": "[parameters('dataCollectionEndpointName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "networkAcls": { "publicNetworkAccess": "Enabled" }
+      }
+    },
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2024-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', parameters('dataCollectionEndpointName'))]"
+      ],
+      "properties": {
+        "dataCollectionEndpointId": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', parameters('dataCollectionEndpointName'))]",
+        "directDataSources": {
+          "otelLogs": [
+            {
+              "streams": ["Microsoft-OTel-Logs"],
+              "enrichWithResourceAttributes": ["*"],
+              "name": "otelLogsDirectSource"
+            }
+          ]
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+              "name": "logAnalyticsDest"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": ["Microsoft-OTel-Logs"],
+            "destinations": ["logAnalyticsDest"]
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "dcrImmutableId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName')), '2024-03-11', 'full').properties.immutableId]"
+    },
+    "dceLogsEndpoint": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', parameters('dataCollectionEndpointName')), '2024-03-11', 'full').properties.logsIngestion.endpoint]"
+    },
+    "dcrResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}
+```
+
+Deploy the template:
+
+```bash
+DCE_NAME="otel-azm-dce"
+DCR_NAME="otel-azm-dcr"
+
+DEPLOY_OUTPUT=$(az deployment group create \
+    --resource-group "$RG_NAME" \
+    --template-file dcr-arm-template.json \
+    --parameters \
+        location="$LOCATION" \
+        logAnalyticsWorkspaceResourceId="$WORKSPACE_RESOURCE_ID" \
+        dataCollectionEndpointName="$DCE_NAME" \
+        dataCollectionRuleName="$DCR_NAME" \
+    --output json)
+
+DCR_IMMUTABLE_ID=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.dcrImmutableId.value')
+DCE_LOGS_ENDPOINT=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.dceLogsEndpoint.value')
+DCR_RESOURCE_ID=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.dcrResourceId.value')
+
+echo "DCR Immutable ID:        $DCR_IMMUTABLE_ID"
+echo "DCE Logs Endpoint:       $DCE_LOGS_ENDPOINT"
+echo "DCR Resource ID:         $DCR_RESOURCE_ID"
+```
+
+> **Note**: If the deployment fails with `Table for output stream 'Microsoft-OTel-Logs' is not available`, the workspace may be recovering from a soft-delete. Wait 30 seconds and retry the deployment.
+
+### Step 5: Create a Service Principal
+
+```bash
+SP_NAME="otel-azm-logs-sp"
+
+SP_JSON=$(az ad sp create-for-rbac \
+    --name "$SP_NAME" \
+    --role "Monitoring Metrics Publisher" \
+    --scopes "$DCR_RESOURCE_ID" \
+    --output json)
+
+SP_APP_ID=$(echo "$SP_JSON" | jq -r '.appId')
+SP_PASSWORD=$(echo "$SP_JSON" | jq -r '.password')
+TENANT_ID=$(echo "$SP_JSON" | jq -r '.tenant')
+
+echo "SP App ID:   $SP_APP_ID"
+echo "Tenant ID:   $TENANT_ID"
+```
+
+> **Important**: Save the `SP_PASSWORD` securely. It is only shown once at creation time.
+
+### Step 6: Construct the OTLP Endpoint URL
+
+```bash
+OTLP_ENDPOINT="${DCE_LOGS_ENDPOINT}/dataCollectionRules/${DCR_IMMUTABLE_ID}/streams/Microsoft-OTLP-Logs/otlp/v1/logs"
+echo "OTLP Endpoint: $OTLP_ENDPOINT"
+```
+
+The full URL format is:
+```
+https://<dce-domain>/dataCollectionRules/<dcr-immutable-id>/streams/Microsoft-OTLP-Logs/otlp/v1/logs
+```
+
+### Step 7: Create the Kubernetes Secret
+
+Create a namespace (or use an existing one) and store the Azure credentials:
+
+```bash
+NAMESPACE="otel-azure-logs"
+oc new-project "$NAMESPACE" 2>/dev/null || true
+
+oc -n "$NAMESPACE" create secret generic azure-monitor-credentials \
+    --from-literal=AZURE_CLIENT_ID="$SP_APP_ID" \
+    --from-literal=AZURE_CLIENT_SECRET="$SP_PASSWORD" \
+    --from-literal=AZURE_TENANT_ID="$TENANT_ID" \
+    --from-literal=AZURE_OTLP_ENDPOINT="$OTLP_ENDPOINT"
+```
+
+### Step 8: Deploy the OpenTelemetry Collector
+
+Apply the following OTel Collector CR. It uses the `oauth2client` extension to authenticate with Azure AD and the `otlphttp` exporter to send logs to Azure Monitor:
+
+```bash
+cat <<'EOF' | oc apply -n "$NAMESPACE" -f -
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-logs-gateway
+spec:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  mode: deployment
+  env:
+    - name: AZURE_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: azure-monitor-credentials
+          key: AZURE_CLIENT_ID
+    - name: AZURE_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: azure-monitor-credentials
+          key: AZURE_CLIENT_SECRET
+    - name: AZURE_TENANT_ID
+      valueFrom:
+        secretKeyRef:
+          name: azure-monitor-credentials
+          key: AZURE_TENANT_ID
+    - name: AZURE_OTLP_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: azure-monitor-credentials
+          key: AZURE_OTLP_ENDPOINT
+  config:
+    extensions:
+      oauth2client:
+        client_id: ${env:AZURE_CLIENT_ID}
+        client_secret: ${env:AZURE_CLIENT_SECRET}
+        token_url: "https://login.microsoftonline.com/${env:AZURE_TENANT_ID}/oauth2/v2.0/token"
+        scopes: ["https://monitor.azure.com/.default"]
+
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 20
+      transform:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - merge_maps(attributes, resource.attributes, "insert")
+      batch:
+        send_batch_max_size: 10240
+        send_batch_size: 8192
+        timeout: 5s
+
+    exporters:
+      debug:
+        verbosity: detailed
+      otlphttp/azure:
+        auth:
+          authenticator: oauth2client
+        logs_endpoint: "${env:AZURE_OTLP_ENDPOINT}"
+
+    service:
+      extensions: [oauth2client]
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, transform, batch]
+          exporters: [otlphttp/azure, debug]
+EOF
+```
+
+Wait for the collector to be ready:
+
+```bash
+oc -n "$NAMESPACE" wait deployment/otel-logs-gateway-collector \
+    --for=condition=Available --timeout=120s
+```
+
+### Step 9: Create the logcollector Service Account and Grant Permissions
+
+The `logcollector` service account must exist before the ClusterLogForwarder is created:
+
+```bash
+oc -n openshift-logging create serviceaccount logcollector
+
+oc adm policy add-cluster-role-to-user collect-application-logs \
+    system:serviceaccount:openshift-logging:logcollector
+```
+
+### Step 10: Create the ClusterLogForwarder
+
+Replace `<NAMESPACE>` with your actual namespace (e.g., `otel-azure-logs`):
+
+```bash
+COLLECTOR_SERVICE="otel-logs-gateway-collector.${NAMESPACE}.svc.cluster.local"
+
+cat <<EOF | oc apply -f -
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+  annotations:
+    observability.openshift.io/tech-preview-otlp-output: "enabled"
+spec:
+  managementState: Managed
+  serviceAccount:
+    name: logcollector
+  filters:
+    - name: multiline-exceptions
+      type: detectMultilineException
+  outputs:
+    - name: otel-collector
+      type: otlp
+      otlp:
+        url: http://${COLLECTOR_SERVICE}:4318/v1/logs
+  pipelines:
+    - name: app-logs-to-azure
+      inputRefs:
+        - application
+      outputRefs:
+        - otel-collector
+      filterRefs:
+        - multiline-exceptions
+EOF
+```
+
+Wait for the CLO collector pods to start:
+
+```bash
+oc -n openshift-logging wait pod \
+    -l app.kubernetes.io/component=collector \
+    --for=condition=Ready --timeout=120s
+```
+
+### Step 11: Deploy a Log Generator (Optional)
+
+To generate test logs, annotate the namespace and deploy the log generator:
+
+```bash
+oc annotate namespace "$NAMESPACE" \
+    openshift.io/sa.scc.uid-range=1000/1000 --overwrite
+oc annotate namespace "$NAMESPACE" \
+    openshift.io/sa.scc.supplemental-groups=3000/1000 --overwrite
+
+cat <<'EOF' | oc apply -n "$NAMESPACE" -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-log-plaintext-config
+data:
+  ocp_logtest.cfg: --rate 60.0
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    run: otel-logtest-plaintext
+    test: otel-logtest-plaintext
+  name: app-log-plaintext-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      generateName: otel-logtest-
+      labels:
+        run: otel-logtest-plaintext
+        test: otel-logtest-plaintext
+    spec:
+      containers:
+      - image: quay.io/openshifttest/ocp-logtest@sha256:6e2973d7d454ce412ad90e99ce584bf221866953da42858c4629873e53778606
+        imagePullPolicy: IfNotPresent
+        name: app-log-plaintext
+        resources: {}
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /var/lib/svt
+          name: config
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - configMap:
+          name: app-log-plaintext-config
+        name: config
+EOF
+```
+
+### Step 12: Verify Logs in Azure Monitor
+
+Wait 5-10 minutes for Azure Monitor ingestion, then query the `OTelLogs` table:
+
+```bash
+az monitor log-analytics query \
+    --workspace "$WORKSPACE_CUSTOMER_ID" \
+    --analytics-query "OTelLogs | where Body has 'SVTLogger' | take 10" \
+    --output table
+```
+
+You can also query for all recent logs:
+
+```bash
+az monitor log-analytics query \
+    --workspace "$WORKSPACE_CUSTOMER_ID" \
+    --analytics-query "OTelLogs | order by TimeGenerated desc | take 20" \
+    --output table
+```
+
+To check the OTel Collector logs for errors:
+
+```bash
+oc -n "$NAMESPACE" logs deployment/otel-logs-gateway-collector | \
+    grep -iE "(error|fail|reject)"
+```
+
+### Step 13: Cleanup
+
+Remove all resources when done:
+
+```bash
+# 1. Delete ClusterLogForwarder
+oc delete clusterlogforwarder instance -n openshift-logging --ignore-not-found=true
+
+# 2. Remove logcollector role binding and SA
+oc adm policy remove-cluster-role-from-user collect-application-logs \
+    system:serviceaccount:openshift-logging:logcollector
+oc -n openshift-logging delete serviceaccount logcollector --ignore-not-found=true
+
+# 3. Delete the test namespace (removes OTel Collector, log generator, secrets)
+oc delete project "$NAMESPACE"
+
+# 4. Delete Azure service principal
+az ad app delete --id "$SP_APP_ID"
+
+# 5. Delete Azure resource group (cascades to workspace, DCE, DCR)
+az group delete --name "$RG_NAME" --yes
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| CLF status: `ServiceAccount "logcollector" not found` | SA not created before CLF | Create the SA first: `oc -n openshift-logging create serviceaccount logcollector` |
+| CLF validation: `requires a valid tech-preview annotation` | Missing OTLP annotation | Add `observability.openshift.io/tech-preview-otlp-output: "enabled"` annotation to CLF |
+| CLF output validation: `Additional type specific spec is required` | Wrong OTLP URL field | Use `otlp.url` (nested under `otlp`), not top-level `url` |
+| DCR deployment: `Table for output stream ... is not available` | Workspace recovering from soft-delete | Wait 30s and retry, or purge the soft-deleted workspace first |
+| No logs in Azure Monitor after 15+ minutes | Wrong table name in query | Query `OTelLogs` (not `OTLPLogs`) |
+| Collector export errors with 401/403 | Wrong OAuth2 scope or SP permissions | Verify scope is `https://monitor.azure.com/.default` and SP has `Monitoring Metrics Publisher` role on the DCR |
+| Log generator pods not starting | SCC restrictions | Annotate namespace: `openshift.io/sa.scc.uid-range=1000/1000` |
+
+## Additional Information
+
+- [Azure Monitor OTLP Ingestion with OTel Collector](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/opentelemetry-protocol-ingestion)
+- [Azure Monitor OTelLogs Table Reference](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/otellogs)
+- [OTel Collector Azure Authentication Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/azureauthextension)
+- [ClusterLogForwarder API (observability.openshift.io/v1)](https://docs.openshift.com/container-platform/latest/observability/logging/log_collection_forwarding/configuring-log-forwarding.html)

--- a/tests/e2e-otel/azuremonitorlogs/app-plaintext-logs-assert.yaml
+++ b/tests/e2e-otel/azuremonitorlogs/app-plaintext-logs-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    run: otel-logtest-plaintext
+    test: otel-logtest-plaintext
+  name: app-log-plaintext-rc
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-otel/azuremonitorlogs/app-plaintext-logs.yaml
+++ b/tests/e2e-otel/azuremonitorlogs/app-plaintext-logs.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-log-plaintext-config
+data:
+  ocp_logtest.cfg: --rate 60.0
+
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    run: otel-logtest-plaintext
+    test: otel-logtest-plaintext
+  name: app-log-plaintext-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      generateName: otel-logtest-
+      labels:
+        run: otel-logtest-plaintext
+        test: otel-logtest-plaintext
+    spec:
+      containers:
+      - image: quay.io/openshifttest/ocp-logtest@sha256:6e2973d7d454ce412ad90e99ce584bf221866953da42858c4629873e53778606
+        imagePullPolicy: IfNotPresent
+        name: app-log-plaintext
+        resources: {}
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        volumeMounts:
+        - mountPath: /var/lib/svt
+          name: config
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+      - configMap:
+          name: app-log-plaintext-config
+        name: config

--- a/tests/e2e-otel/azuremonitorlogs/chainsaw-test.yaml
+++ b/tests/e2e-otel/azuremonitorlogs/chainsaw-test.yaml
@@ -1,0 +1,65 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: azuremonitorlogs
+spec:
+  description: "Test forwarding cluster logs to Azure Monitor via OTel Collector and ClusterLogForwarder"
+  template: true
+  steps:
+  - name: Create Azure Monitor resources and credentials
+    try:
+    - script:
+        timeout: 10m
+        content: ./create-azure-monitor-resources.sh
+    cleanup:
+    - script:
+        timeout: 5m
+        content: ./delete-azure-monitor-resources.sh
+
+  - name: Deploy OTel Collector with Azure Monitor exporter
+    try:
+    - apply:
+        file: otel-collector.yaml
+    - assert:
+        timeout: 3m
+        file: otel-collector-assert.yaml
+
+  - name: Grant log collector permissions and deploy ClusterLogForwarder
+    try:
+    - script:
+        timeout: 5m
+        content: ./setup-cluster-log-forwarder.sh
+    cleanup:
+    - script:
+        timeout: 2m
+        content: ./cleanup-cluster-log-forwarder.sh
+
+  - name: Deploy log generator application
+    try:
+    - command:
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.uid-range=1000/1000
+        - --overwrite
+        entrypoint: kubectl
+    - command:
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.supplemental-groups=3000/1000
+        - --overwrite
+        entrypoint: kubectl
+    - apply:
+        file: app-plaintext-logs.yaml
+    - assert:
+        timeout: 2m
+        file: app-plaintext-logs-assert.yaml
+
+  - name: Verify logs are received in Azure Monitor
+    try:
+    - script:
+        timeout: 16m
+        content: ./check_azure_logs.sh

--- a/tests/e2e-otel/azuremonitorlogs/check_azure_logs.sh
+++ b/tests/e2e-otel/azuremonitorlogs/check_azure_logs.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -uo pipefail
+
+COLLECTOR_NAME="otel-logs-gateway-collector"
+
+echo "--- Verifying logs in Azure Monitor ---"
+
+# 1. Get workspace customer ID from ConfigMap
+WORKSPACE_CUSTOMER_ID=$(oc -n "$NAMESPACE" get configmap azure-monitor-test-config -o jsonpath='{.data.WORKSPACE_CUSTOMER_ID}')
+if [ -z "$WORKSPACE_CUSTOMER_ID" ]; then
+    echo "ERROR: Could not retrieve WORKSPACE_CUSTOMER_ID from ConfigMap"
+    exit 1
+fi
+echo "  Workspace Customer ID: $WORKSPACE_CUSTOMER_ID"
+
+# 2. Check OTel Collector pod logs for export errors
+echo "Checking OTel Collector pod for errors..."
+COLLECTOR_POD=$(oc -n "$NAMESPACE" get pods -l app.kubernetes.io/name="$COLLECTOR_NAME" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+if [ -n "$COLLECTOR_POD" ]; then
+    ERRORS=$(oc -n "$NAMESPACE" logs "$COLLECTOR_POD" 2>/dev/null | grep -c "exporting failed" || true)
+    if [ "$ERRORS" -gt 0 ]; then
+        echo "WARNING: Found $ERRORS export errors in collector logs"
+        oc -n "$NAMESPACE" logs "$COLLECTOR_POD" 2>/dev/null | grep "exporting failed" | tail -5
+    else
+        echo "  No export errors found in collector logs"
+    fi
+
+    EXPORTED=$(oc -n "$NAMESPACE" logs "$COLLECTOR_POD" 2>/dev/null | grep -c "LogsExporter" || true)
+    echo "  Log export entries in collector: $EXPORTED"
+else
+    echo "WARNING: Could not find collector pod"
+fi
+
+# 3. Query Azure Monitor for OTelLogs containing SVTLogger
+echo "Querying Azure Monitor OTelLogs table..."
+MAX_RETRIES=25
+RETRY_INTERVAL=30
+
+for i in $(seq 1 $MAX_RETRIES); do
+    echo "  Attempt $i/$MAX_RETRIES: Querying for SVTLogger logs..."
+    RESULT=$(az monitor log-analytics query \
+        --workspace "$WORKSPACE_CUSTOMER_ID" \
+        --analytics-query "OTelLogs | where Body has 'SVTLogger' | take 10" \
+        --output json 2>/dev/null || echo "[]")
+
+    COUNT=$(echo "$RESULT" | jq '. | length' 2>/dev/null || echo "0")
+
+    if [ "$COUNT" -gt 0 ] && [ "$COUNT" != "null" ]; then
+        echo "Found $COUNT log entries containing 'SVTLogger' in Azure Monitor"
+        echo "Sample log entry:"
+        echo "$RESULT" | jq '.[0]' 2>/dev/null
+        echo "--- Azure Monitor log verification PASSED ---"
+        exit 0
+    fi
+
+    echo "  No logs found yet, waiting ${RETRY_INTERVAL}s... (elapsed: $((i * RETRY_INTERVAL))s)"
+    sleep $RETRY_INTERVAL
+done
+
+echo "ERROR: No SVTLogger logs found in Azure Monitor after $((MAX_RETRIES * RETRY_INTERVAL))s"
+
+# Re-check collector for export errors
+if [ -n "$COLLECTOR_POD" ]; then
+    echo "--- Collector export errors ---"
+    oc -n "$NAMESPACE" logs "$COLLECTOR_POD" 2>/dev/null | grep -iE "(error|fail|reject|denied|unauthorized|403|401|500)" | tail -20 || echo "  No errors found"
+    echo "--- Collector pod logs (last 50 lines) ---"
+    oc -n "$NAMESPACE" logs "$COLLECTOR_POD" --tail=50 2>/dev/null || true
+fi
+
+exit 1

--- a/tests/e2e-otel/azuremonitorlogs/cleanup-cluster-log-forwarder.sh
+++ b/tests/e2e-otel/azuremonitorlogs/cleanup-cluster-log-forwarder.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+echo "--- Cleaning up ClusterLogForwarder ---"
+
+oc delete clusterlogforwarder instance -n openshift-logging --ignore-not-found=true 2>/dev/null || true
+
+# Remove cluster role bindings granted to logcollector
+oc adm policy remove-cluster-role-from-user collect-application-logs system:serviceaccount:openshift-logging:logcollector 2>/dev/null || true
+
+# Remove the logcollector service account
+oc -n openshift-logging delete serviceaccount logcollector --ignore-not-found=true 2>/dev/null || true
+
+echo "--- ClusterLogForwarder cleanup completed ---"

--- a/tests/e2e-otel/azuremonitorlogs/create-azure-monitor-resources.sh
+++ b/tests/e2e-otel/azuremonitorlogs/create-azure-monitor-resources.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -e
+
+LOCATION="eastus"
+RG_NAME="otel-azure-monitor-logs"
+WORKSPACE_NAME="otel-azm-logs"
+DCE_NAME="otel-azm-dce"
+DCR_NAME="otel-azm-dcr"
+SP_NAME="otel-azm-logs-sp"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "--- Setting up Azure Monitor resources for OTLP log ingestion ---"
+echo "  Resource Group: $RG_NAME"
+echo "  Location: $LOCATION"
+echo "  Namespace: $NAMESPACE"
+echo "-------------------------------------------------------------------"
+
+# Clean up any pre-existing resource group from a previous run
+if [ "$(az group exists --name "$RG_NAME")" = "true" ]; then
+    echo "Deleting existing resource group $RG_NAME (waiting for completion)..."
+    az group delete --name "$RG_NAME" --yes || true
+fi
+
+# Delete any pre-existing service principal
+EXISTING_SP=$(az ad sp list --display-name "$SP_NAME" --query "[0].appId" -o tsv 2>/dev/null || echo "")
+if [ -n "$EXISTING_SP" ]; then
+    echo "Deleting existing service principal $SP_NAME ($EXISTING_SP)..."
+    az ad app delete --id "$EXISTING_SP" || true
+fi
+
+# 1. Create resource group
+echo "Creating resource group: $RG_NAME"
+az group create --name "$RG_NAME" --location "$LOCATION" --output none || { echo "Failed to create resource group"; exit 1; }
+
+# 2. Purge any soft-deleted workspace with the same name to get a clean workspace
+SUBSCRIPTION_ID=$(az account show --query "id" -o tsv)
+echo "Checking for soft-deleted workspace: $WORKSPACE_NAME"
+az rest --method delete \
+    --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.OperationalInsights/workspaces/${WORKSPACE_NAME}?api-version=2023-09-01&force=true" \
+    2>/dev/null || true
+
+echo "Creating Log Analytics workspace: $WORKSPACE_NAME"
+az monitor log-analytics workspace create \
+    --resource-group "$RG_NAME" \
+    --workspace-name "$WORKSPACE_NAME" \
+    --location "$LOCATION" \
+    --output none || { echo "Failed to create Log Analytics workspace"; exit 1; }
+
+WORKSPACE_RESOURCE_ID=$(az monitor log-analytics workspace show \
+    --resource-group "$RG_NAME" \
+    --workspace-name "$WORKSPACE_NAME" \
+    --query "id" -o tsv)
+
+WORKSPACE_CUSTOMER_ID=$(az monitor log-analytics workspace show \
+    --resource-group "$RG_NAME" \
+    --workspace-name "$WORKSPACE_NAME" \
+    --query "customerId" -o tsv)
+
+echo "  Workspace Resource ID: $WORKSPACE_RESOURCE_ID"
+echo "  Workspace Customer ID: $WORKSPACE_CUSTOMER_ID"
+
+# 3. Deploy DCE and DCR using ARM template (API version 2024-03-11)
+echo "Deploying Data Collection Endpoint and Rule via ARM template..."
+DEPLOY_OUTPUT=""
+for attempt in 1 2 3; do
+    DEPLOY_OUTPUT=$(az deployment group create \
+        --resource-group "$RG_NAME" \
+        --template-file "${SCRIPT_DIR}/dcr-arm-template.json" \
+        --parameters \
+            location="$LOCATION" \
+            logAnalyticsWorkspaceResourceId="$WORKSPACE_RESOURCE_ID" \
+            dataCollectionEndpointName="$DCE_NAME" \
+            dataCollectionRuleName="$DCR_NAME" \
+        --output json 2>&1) && break
+    echo "  DCR deployment attempt $attempt failed, retrying in 30s..."
+    echo "  Error: $DEPLOY_OUTPUT"
+    sleep 30
+done
+if ! echo "$DEPLOY_OUTPUT" | jq -e '.properties.outputs' > /dev/null 2>&1; then
+    echo "Failed to deploy DCE/DCR ARM template after 3 attempts"
+    echo "$DEPLOY_OUTPUT"
+    exit 1
+fi
+
+DCR_IMMUTABLE_ID=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.dcrImmutableId.value')
+DCE_LOGS_ENDPOINT=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.dceLogsEndpoint.value')
+DCR_RESOURCE_ID=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.dcrResourceId.value')
+
+echo "  DCR Immutable ID: $DCR_IMMUTABLE_ID"
+echo "  DCE Logs Ingestion Endpoint: $DCE_LOGS_ENDPOINT"
+echo "  DCR Resource ID: $DCR_RESOURCE_ID"
+
+# 4. Create Service Principal and assign Monitoring Metrics Publisher role on DCR
+echo "Creating Service Principal: $SP_NAME"
+SP_JSON=$(az ad sp create-for-rbac \
+    --name "$SP_NAME" \
+    --role "Monitoring Metrics Publisher" \
+    --scopes "$DCR_RESOURCE_ID" \
+    --output json) || { echo "Failed to create service principal"; exit 1; }
+
+SP_APP_ID=$(echo "$SP_JSON" | jq -r '.appId')
+SP_PASSWORD=$(echo "$SP_JSON" | jq -r '.password')
+TENANT_ID=$(echo "$SP_JSON" | jq -r '.tenant')
+
+echo "  SP App ID: $SP_APP_ID"
+echo "  Tenant ID: $TENANT_ID"
+
+# 5. Construct the OTLP ingestion endpoint (full URL for logs_endpoint config)
+OTLP_ENDPOINT="${DCE_LOGS_ENDPOINT}/dataCollectionRules/${DCR_IMMUTABLE_ID}/streams/Microsoft-OTLP-Logs/otlp/v1/logs"
+echo "  OTLP Endpoint: $OTLP_ENDPOINT"
+
+# 6. Create Kubernetes secret with Azure credentials and OTLP endpoint
+echo "Creating Kubernetes secret: azure-monitor-credentials in namespace $NAMESPACE"
+oc -n "$NAMESPACE" create secret generic azure-monitor-credentials \
+    --from-literal=AZURE_CLIENT_ID="$SP_APP_ID" \
+    --from-literal=AZURE_CLIENT_SECRET="$SP_PASSWORD" \
+    --from-literal=AZURE_TENANT_ID="$TENANT_ID" \
+    --from-literal=AZURE_OTLP_ENDPOINT="$OTLP_ENDPOINT" || { echo "Failed to create K8s secret"; exit 1; }
+
+# 7. Store test metadata in a ConfigMap for verification and cleanup scripts
+echo "Creating ConfigMap: azure-monitor-test-config in namespace $NAMESPACE"
+oc -n "$NAMESPACE" create configmap azure-monitor-test-config \
+    --from-literal=RESOURCE_GROUP="$RG_NAME" \
+    --from-literal=WORKSPACE_CUSTOMER_ID="$WORKSPACE_CUSTOMER_ID" \
+    --from-literal=SP_APP_ID="$SP_APP_ID" \
+    --from-literal=SP_NAME="$SP_NAME" || { echo "Failed to create ConfigMap"; exit 1; }
+
+echo "--- Azure Monitor resources created successfully ---"

--- a/tests/e2e-otel/azuremonitorlogs/dcr-arm-template.json
+++ b/tests/e2e-otel/azuremonitorlogs/dcr-arm-template.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string"
+    },
+    "logAnalyticsWorkspaceResourceId": {
+      "type": "string"
+    },
+    "dataCollectionEndpointName": {
+      "type": "string",
+      "defaultValue": "otel-azm-dce"
+    },
+    "dataCollectionRuleName": {
+      "type": "string",
+      "defaultValue": "otel-azm-dcr"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Insights/dataCollectionEndpoints",
+      "apiVersion": "2024-03-11",
+      "name": "[parameters('dataCollectionEndpointName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "networkAcls": {
+          "publicNetworkAccess": "Enabled"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Insights/dataCollectionRules",
+      "apiVersion": "2024-03-11",
+      "name": "[parameters('dataCollectionRuleName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Insights/dataCollectionEndpoints', parameters('dataCollectionEndpointName'))]"
+      ],
+      "properties": {
+        "dataCollectionEndpointId": "[resourceId('Microsoft.Insights/dataCollectionEndpoints', parameters('dataCollectionEndpointName'))]",
+        "directDataSources": {
+          "otelLogs": [
+            {
+              "streams": ["Microsoft-OTel-Logs"],
+              "enrichWithResourceAttributes": ["*"],
+              "name": "otelLogsDirectSource"
+            }
+          ]
+        },
+        "destinations": {
+          "logAnalytics": [
+            {
+              "workspaceResourceId": "[parameters('logAnalyticsWorkspaceResourceId')]",
+              "name": "logAnalyticsDest"
+            }
+          ]
+        },
+        "dataFlows": [
+          {
+            "streams": ["Microsoft-OTel-Logs"],
+            "destinations": ["logAnalyticsDest"]
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "dcrImmutableId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName')), '2024-03-11', 'full').properties.immutableId]"
+    },
+    "dceLogsEndpoint": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Insights/dataCollectionEndpoints', parameters('dataCollectionEndpointName')), '2024-03-11', 'full').properties.logsIngestion.endpoint]"
+    },
+    "dcrResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Insights/dataCollectionRules', parameters('dataCollectionRuleName'))]"
+    }
+  }
+}

--- a/tests/e2e-otel/azuremonitorlogs/dcr-arm-template.json
+++ b/tests/e2e-otel/azuremonitorlogs/dcr-arm-template.json
@@ -34,7 +34,6 @@
       "apiVersion": "2024-03-11",
       "name": "[parameters('dataCollectionRuleName')]",
       "location": "[parameters('location')]",
-      "kind": "Direct",
       "dependsOn": [
         "[resourceId('Microsoft.Insights/dataCollectionEndpoints', parameters('dataCollectionEndpointName'))]"
       ],

--- a/tests/e2e-otel/azuremonitorlogs/dcr-arm-template.json
+++ b/tests/e2e-otel/azuremonitorlogs/dcr-arm-template.json
@@ -34,6 +34,7 @@
       "apiVersion": "2024-03-11",
       "name": "[parameters('dataCollectionRuleName')]",
       "location": "[parameters('location')]",
+      "kind": "Direct",
       "dependsOn": [
         "[resourceId('Microsoft.Insights/dataCollectionEndpoints', parameters('dataCollectionEndpointName'))]"
       ],

--- a/tests/e2e-otel/azuremonitorlogs/delete-azure-monitor-resources.sh
+++ b/tests/e2e-otel/azuremonitorlogs/delete-azure-monitor-resources.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+RG_NAME="otel-azure-monitor-logs"
+
+echo "--- Cleaning up Azure Monitor resources ---"
+
+# 1. Delete the service principal
+SP_APP_ID=$(oc -n "$NAMESPACE" get configmap azure-monitor-test-config -o jsonpath='{.data.SP_APP_ID}' 2>/dev/null || echo "")
+if [ -n "$SP_APP_ID" ]; then
+    echo "Deleting service principal: $SP_APP_ID"
+    az ad app delete --id "$SP_APP_ID" || true
+else
+    SP_NAME="otel-azm-logs-sp"
+    FALLBACK_SP=$(az ad sp list --display-name "$SP_NAME" --query "[0].appId" -o tsv 2>/dev/null || echo "")
+    if [ -n "$FALLBACK_SP" ]; then
+        echo "Deleting service principal by name: $SP_NAME ($FALLBACK_SP)"
+        az ad app delete --id "$FALLBACK_SP" || true
+    fi
+fi
+
+# 2. Delete the resource group (cascades to workspace, DCE, DCR)
+if [ "$(az group exists --name "$RG_NAME")" = "true" ]; then
+    echo "Deleting resource group: $RG_NAME"
+    az group delete --name "$RG_NAME" --yes || true
+fi
+
+# 3. Delete Kubernetes resources
+oc -n "$NAMESPACE" delete secret azure-monitor-credentials --ignore-not-found=true 2>/dev/null || true
+oc -n "$NAMESPACE" delete configmap azure-monitor-test-config --ignore-not-found=true 2>/dev/null || true
+
+echo "--- Azure Monitor cleanup completed ---"

--- a/tests/e2e-otel/azuremonitorlogs/otel-collector-assert.yaml
+++ b/tests/e2e-otel/azuremonitorlogs/otel-collector-assert.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-logs-gateway-collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-logs-gateway-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP

--- a/tests/e2e-otel/azuremonitorlogs/otel-collector.yaml
+++ b/tests/e2e-otel/azuremonitorlogs/otel-collector.yaml
@@ -1,0 +1,75 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-logs-gateway
+spec:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  mode: deployment
+  env:
+    - name: AZURE_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: azure-monitor-credentials
+          key: AZURE_CLIENT_ID
+    - name: AZURE_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: azure-monitor-credentials
+          key: AZURE_CLIENT_SECRET
+    - name: AZURE_TENANT_ID
+      valueFrom:
+        secretKeyRef:
+          name: azure-monitor-credentials
+          key: AZURE_TENANT_ID
+    - name: AZURE_OTLP_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: azure-monitor-credentials
+          key: AZURE_OTLP_ENDPOINT
+  config:
+    extensions:
+      oauth2client:
+        client_id: ${env:AZURE_CLIENT_ID}
+        client_secret: ${env:AZURE_CLIENT_SECRET}
+        token_url: "https://login.microsoftonline.com/${env:AZURE_TENANT_ID}/oauth2/v2.0/token"
+        scopes: ["https://monitor.azure.com/.default"]
+
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 20
+      transform:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - merge_maps(attributes, resource.attributes, "insert")
+      batch:
+        send_batch_max_size: 10240
+        send_batch_size: 8192
+        timeout: 5s
+
+    exporters:
+      debug:
+        verbosity: detailed
+      otlphttp/azure:
+        auth:
+          authenticator: oauth2client
+        logs_endpoint: "${env:AZURE_OTLP_ENDPOINT}"
+
+    service:
+      extensions: [oauth2client]
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, transform, batch]
+          exporters: [otlphttp/azure, debug]

--- a/tests/e2e-otel/azuremonitorlogs/setup-cluster-log-forwarder.sh
+++ b/tests/e2e-otel/azuremonitorlogs/setup-cluster-log-forwarder.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+echo "--- Setting up ClusterLogForwarder ---"
+
+COLLECTOR_SERVICE="otel-logs-gateway-collector.${NAMESPACE}.svc.cluster.local"
+echo "  OTel Collector service: $COLLECTOR_SERVICE"
+
+# 1. Create the logcollector service account (required before CLF creation)
+echo "Creating logcollector service account..."
+oc -n openshift-logging create serviceaccount logcollector 2>/dev/null || true
+
+# 2. Grant log collector permissions
+echo "Granting log collector permissions..."
+oc adm policy add-cluster-role-to-user collect-application-logs system:serviceaccount:openshift-logging:logcollector
+
+# 3. Apply ClusterLogForwarder
+echo "Creating ClusterLogForwarder..."
+cat <<EOF | oc apply -f -
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+  annotations:
+    observability.openshift.io/tech-preview-otlp-output: "enabled"
+spec:
+  managementState: Managed
+  serviceAccount:
+    name: logcollector
+  filters:
+    - name: multiline-exceptions
+      type: detectMultilineException
+  outputs:
+    - name: otel-collector
+      type: otlp
+      otlp:
+        url: http://${COLLECTOR_SERVICE}:4318/v1/logs
+  pipelines:
+    - name: app-logs-to-azure
+      inputRefs:
+        - application
+      outputRefs:
+        - otel-collector
+      filterRefs:
+        - multiline-exceptions
+EOF
+
+# 4. Wait for log collector pods to be ready
+echo "Waiting for log collector pods to be ready..."
+sleep 10
+oc -n openshift-logging wait pod -l app.kubernetes.io/component=collector --for=condition=Ready --timeout=120s 2>/dev/null || \
+    oc -n openshift-logging wait pod -l component=collector --for=condition=Ready --timeout=120s 2>/dev/null || \
+    echo "WARNING: Could not verify collector pod readiness, continuing..."
+
+echo "--- ClusterLogForwarder setup completed ---"


### PR DESCRIPTION
## Summary
- Adds a Chainsaw e2e test that validates forwarding OpenShift application logs to Azure Monitor via an OTel Collector with OTLP/HTTP export and OAuth2 authentication
- Provisions Azure resources (Log Analytics workspace, DCE, DCR) via ARM template, deploys OTel Collector with `oauth2client` extension, sets up ClusterLogForwarder with OTLP output, and verifies logs arrive in the `OTelLogs` table
- Includes README with automated test documentation and comprehensive manual setup guide

## Test plan
- [x] Test passes end-to-end on OpenShift cluster with CLO 6.x and OTel Operator
- [x] Azure Monitor `OTelLogs` table receives SVTLogger entries
- [x] Cleanup removes all Azure resources (RG, SP) and cluster resources (CLF, SA, role bindings)
- [x] Code review, security review, and CodeRabbit review completed — findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed end-to-end guide for forwarding OpenShift cluster logs to Azure Monitor using OpenTelemetry, including prerequisites, architecture/flow, verification queries, troubleshooting, and full teardown steps.

* **Tests**
  * Added an end-to-end log forwarding test covering Azure Monitor resource provisioning, deployment of an OTel logs gateway, configuration of ClusterLogForwarder, generation of plaintext logs, and ingestion verification.
  * Added supporting Kubernetes manifests and helper scripts for collector assertions, setup/cleanup, and Azure/collector-side log checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->