### PR TITLE
Add e2e test for k8s_leader_elector extension

### DIFF
--- a/tests/e2e-otel/k8sleaderelectorext/chainsaw-test.yaml
+++ b/tests/e2e-otel/k8sleaderelectorext/chainsaw-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: k8sleaderelectorext
+spec:
+  steps:
+  - name: Create OTEL collector with k8s_leader_elector extension and k8s_cluster receiver using 2 replicas
+    try:
+    - apply:
+        file: otel-k8sleaderelectorext.yaml
+    - assert:
+        file: otel-k8sleaderelectorext-assert.yaml
+  - name: Wait for leader election and metrics collection
+    try:
+    - sleep:
+        duration: 60s
+  - name: Verify leader election and metrics in the OTEL collector
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_leader_election.sh

--- a/tests/e2e-otel/k8sleaderelectorext/check_leader_election.sh
+++ b/tests/e2e-otel/k8sleaderelectorext/check_leader_election.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# This script verifies the k8s_leader_elector extension is working correctly:
+# 1. A Lease object exists in the test namespace
+# 2. Leader election log messages are present in collector pods
+# 3. Metrics are collected by the leader pod
+
+LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
+NAMESPACE=chainsaw-k8sleaderelectorext
+LEASE_NAME="otel-k8sclusterreceiver-leader"
+
+FOUND_LEASE=false
+FOUND_METRICS=false
+FOUND_LEADER_LOG=false
+
+while ! $FOUND_LEASE || ! $FOUND_METRICS || ! $FOUND_LEADER_LOG; do
+    # Check that the Lease object exists
+    if ! $FOUND_LEASE && kubectl -n $NAMESPACE get lease $LEASE_NAME > /dev/null 2>&1; then
+        HOLDER=$(kubectl -n $NAMESPACE get lease $LEASE_NAME -o jsonpath='{.spec.holderIdentity}')
+        echo "Lease '$LEASE_NAME' found with holder: $HOLDER"
+        FOUND_LEASE=true
+    fi
+
+    PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+
+    for POD in "${PODS[@]}"; do
+        LOGS=$(kubectl -n $NAMESPACE logs $POD --tail=500 2>/dev/null)
+
+        # Check for leader election activity (klog uses capital "Successfully acquired lease")
+        if ! $FOUND_LEADER_LOG && echo "$LOGS" | grep -qi -e "successfully acquired lease" -e "Starting k8sClusterReceiver with leader election"; then
+            echo "Leader election log found in $POD"
+            FOUND_LEADER_LOG=true
+        fi
+
+        # Check for k8s cluster metrics (only the leader should produce these)
+        if ! $FOUND_METRICS && echo "$LOGS" | grep -q "k8s.node.allocatable_cpu"; then
+            echo "Metrics 'k8s.node.allocatable_cpu' found in $POD"
+            FOUND_METRICS=true
+        fi
+    done
+
+    sleep 5
+done
+
+echo ""
+echo "=== Leader Election Extension Verification ==="
+echo "Lease object created: PASS"
+echo "Leader election active: PASS"
+echo "Metrics collected by leader: PASS"
+echo "All checks passed."

--- a/tests/e2e-otel/k8sleaderelectorext/check_leader_election.sh
+++ b/tests/e2e-otel/k8sleaderelectorext/check_leader_election.sh
@@ -2,28 +2,32 @@
 # This script verifies the k8s_leader_elector extension is working correctly:
 # 1. A Lease object exists in the test namespace
 # 2. Leader election log messages are present in collector pods
-# 3. Metrics are collected by the leader pod
+# 3. Metrics are collected by exactly one (leader) pod
+# 4. The non-leader pod does NOT collect metrics (proves exclusivity)
 
 LABEL_SELECTOR="app.kubernetes.io/component=opentelemetry-collector"
 NAMESPACE=chainsaw-k8sleaderelectorext
 LEASE_NAME="otel-k8sclusterreceiver-leader"
 
 FOUND_LEASE=false
-FOUND_METRICS=false
 FOUND_LEADER_LOG=false
+VERIFIED_EXCLUSIVITY=false
 
-while ! $FOUND_LEASE || ! $FOUND_METRICS || ! $FOUND_LEADER_LOG; do
+while ! $FOUND_LEASE || ! $FOUND_LEADER_LOG || ! $VERIFIED_EXCLUSIVITY; do
     # Check that the Lease object exists
-    if ! $FOUND_LEASE && kubectl -n $NAMESPACE get lease $LEASE_NAME > /dev/null 2>&1; then
-        HOLDER=$(kubectl -n $NAMESPACE get lease $LEASE_NAME -o jsonpath='{.spec.holderIdentity}')
-        echo "Lease '$LEASE_NAME' found with holder: $HOLDER"
+    if ! $FOUND_LEASE && kubectl -n "$NAMESPACE" get lease "$LEASE_NAME" > /dev/null 2>&1; then
+        echo "Lease '$LEASE_NAME' exists"
         FOUND_LEASE=true
     fi
 
-    PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
+    PODS=($(kubectl -n "$NAMESPACE" get pods -l "$LABEL_SELECTOR" -o jsonpath='{.items[*].metadata.name}'))
+
+    LEADER_POD=""
+    PODS_WITH_METRICS=0
+    PODS_WITHOUT_METRICS=0
 
     for POD in "${PODS[@]}"; do
-        LOGS=$(kubectl -n $NAMESPACE logs $POD --tail=500 2>/dev/null)
+        LOGS=$(kubectl -n "$NAMESPACE" logs "$POD" --tail=500 2>/dev/null)
 
         # Check for leader election activity (klog uses capital "Successfully acquired lease")
         if ! $FOUND_LEADER_LOG && echo "$LOGS" | grep -qi -e "successfully acquired lease" -e "Starting k8sClusterReceiver with leader election"; then
@@ -31,19 +35,34 @@ while ! $FOUND_LEASE || ! $FOUND_METRICS || ! $FOUND_LEADER_LOG; do
             FOUND_LEADER_LOG=true
         fi
 
-        # Check for k8s cluster metrics (only the leader should produce these)
-        if ! $FOUND_METRICS && echo "$LOGS" | grep -q "k8s.node.allocatable_cpu"; then
-            echo "Metrics 'k8s.node.allocatable_cpu' found in $POD"
-            FOUND_METRICS=true
+        # Track which pods have metrics
+        if echo "$LOGS" | grep -q "k8s.node.allocatable_cpu"; then
+            LEADER_POD="$POD"
+            PODS_WITH_METRICS=$((PODS_WITH_METRICS + 1))
+        else
+            PODS_WITHOUT_METRICS=$((PODS_WITHOUT_METRICS + 1))
         fi
     done
 
-    sleep 5
+    # Verify exclusivity: exactly one pod has metrics, the rest do not
+    if [ "$PODS_WITH_METRICS" -eq 1 ] && [ "$PODS_WITHOUT_METRICS" -gt 0 ]; then
+        echo "Metrics 'k8s.node.allocatable_cpu' found only in leader pod $LEADER_POD"
+        echo "Non-leader pods confirmed not collecting metrics ($PODS_WITHOUT_METRICS standby)"
+        VERIFIED_EXCLUSIVITY=true
+    elif [ "$PODS_WITH_METRICS" -gt 1 ]; then
+        echo "ERROR: $PODS_WITH_METRICS pods are collecting metrics (leader election not enforcing exclusivity)"
+        exit 1
+    fi
+
+    if ! $FOUND_LEASE || ! $FOUND_LEADER_LOG || ! $VERIFIED_EXCLUSIVITY; then
+        sleep 5
+    fi
 done
 
 echo ""
 echo "=== Leader Election Extension Verification ==="
 echo "Lease object created: PASS"
 echo "Leader election active: PASS"
-echo "Metrics collected by leader: PASS"
+echo "Metrics collected by leader only: PASS"
+echo "Non-leader exclusivity verified: PASS"
 echo "All checks passed."

--- a/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext-assert.yaml
+++ b/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext-assert.yaml
@@ -87,6 +87,28 @@ rules:
   - get
   - list
   - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8sleaderelectorext-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8sleaderelectorext-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-k8sleaderelectorext
+  namespace: chainsaw-k8sleaderelectorext
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chainsaw-k8sleaderelectorext-lease-role
+  namespace: chainsaw-k8sleaderelectorext
+rules:
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -102,13 +124,14 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: chainsaw-k8sleaderelectorext-binding
+  name: chainsaw-k8sleaderelectorext-lease-binding
+  namespace: chainsaw-k8sleaderelectorext
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: chainsaw-k8sleaderelectorext-role
+  kind: Role
+  name: chainsaw-k8sleaderelectorext-lease-role
 subjects:
 - kind: ServiceAccount
   name: chainsaw-k8sleaderelectorext

--- a/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext-assert.yaml
+++ b/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext-assert.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-k8sleaderelectorext
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-k8sleaderelectorext
+  namespace: chainsaw-k8sleaderelectorext
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-k8sleaderelectorext-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - quota.openshift.io
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8sleaderelectorext-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8sleaderelectorext-role
+subjects:
+- kind: ServiceAccount
+  name: chainsaw-k8sleaderelectorext
+  namespace: chainsaw-k8sleaderelectorext
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chainsaw-k8sleaderelectorext-collector
+  namespace: chainsaw-k8sleaderelectorext
+status:
+  availableReplicas: 2
+  readyReplicas: 2
+  replicas: 2

--- a/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext.yaml
+++ b/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext.yaml
@@ -82,6 +82,28 @@ rules:
   - get
   - list
   - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8sleaderelectorext-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8sleaderelectorext-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-k8sleaderelectorext
+    namespace: chainsaw-k8sleaderelectorext
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chainsaw-k8sleaderelectorext-lease-role
+  namespace: chainsaw-k8sleaderelectorext
+rules:
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -97,13 +119,14 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: chainsaw-k8sleaderelectorext-binding
+  name: chainsaw-k8sleaderelectorext-lease-binding
+  namespace: chainsaw-k8sleaderelectorext
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: chainsaw-k8sleaderelectorext-role
+  kind: Role
+  name: chainsaw-k8sleaderelectorext-lease-role
 subjects:
   - kind: ServiceAccount
     name: chainsaw-k8sleaderelectorext

--- a/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext.yaml
+++ b/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chainsaw-k8sleaderelectorext
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-k8sleaderelectorext
+  namespace: chainsaw-k8sleaderelectorext
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chainsaw-k8sleaderelectorext-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - quota.openshift.io
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chainsaw-k8sleaderelectorext-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chainsaw-k8sleaderelectorext-role
+subjects:
+  - kind: ServiceAccount
+    name: chainsaw-k8sleaderelectorext
+    namespace: chainsaw-k8sleaderelectorext
+
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: chainsaw-k8sleaderelectorext
+  namespace: chainsaw-k8sleaderelectorext
+spec:
+  mode: deployment
+  replicas: 2
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.0
+  serviceAccount: chainsaw-k8sleaderelectorext
+  config: |
+    extensions:
+      k8s_leader_elector:
+        auth_type: serviceAccount
+        lease_name: otel-k8sclusterreceiver-leader
+        lease_namespace: chainsaw-k8sleaderelectorext
+    receivers:
+      k8s_cluster:
+        distribution: openshift
+        collection_interval: 15s
+        node_conditions_to_report:
+          - Ready
+          - MemoryPressure
+        allocatable_types_to_report:
+          - cpu
+          - memory
+        k8s_leader_elector: k8s_leader_elector
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      extensions: [k8s_leader_elector]
+      pipelines:
+        metrics:
+          receivers: [k8s_cluster]
+          exporters: [debug]


### PR DESCRIPTION
## Summary
- Adds a Chainsaw e2e test for the `k8s_leader_elector` extension under `tests/e2e-otel/k8sleaderelectorext/`
- Deploys a collector with 2 replicas using the `k8s_cluster` receiver integrated with `k8s_leader_elector` extension
- Verifies leader election works on OpenShift: Lease object created, leader elected, only leader collects metrics
- Uses upstream community contrib image (`0.152.0`) since the extension is not yet in the Red Hat collector image

## Test plan
- [x] Test passes on OpenShift 4.21 nightly cluster
- [x] Lease object created in test namespace with correct holder identity
- [x] Leader election log messages present in collector pods
- [x] Cluster metrics (`k8s.node.allocatable_cpu`) collected by leader replica
- [x] RBAC for `coordination.k8s.io/leases` validated (all 7 verbs required)
- [x] Chainsaw cleanup removes all resources after test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for OpenTelemetry Collector leader election in Kubernetes.
  * Verifies that two collector replicas become ready and coordinate leadership through a Kubernetes lease.
  * Confirms leader-election activity and ensures only the elected collector emits cluster metrics.
  * Validates required permissions, Kubernetes cluster receiver operation, and successful metric collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->