### PR TITLE
Update collector image version in tests to 0.158.0 and fix tests. 

### DIFF
--- a/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/create-aws-rolearn-secret.sh
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/create-aws-rolearn-secret.sh
@@ -70,11 +70,16 @@ cat > "$base_trust_file" <<EOF
 }
 EOF
 
-base_role_arn=$(aws iam create-role \
-             --role-name "$base_role_name" \
-             --assume-role-policy-document "file://$base_trust_file" \
-             --query Role.Arn \
-             --output text)
+if base_role_arn=$(aws iam get-role --role-name "$base_role_name" --query Role.Arn --output text 2>/dev/null); then
+  echo "Base role already exists, updating trust policy..."
+  aws iam update-assume-role-policy --role-name "$base_role_name" --policy-document "file://$base_trust_file"
+else
+  base_role_arn=$(aws iam create-role \
+               --role-name "$base_role_name" \
+               --assume-role-policy-document "file://$base_trust_file" \
+               --query Role.Arn \
+               --output text)
+fi
 
 echo "Base role created: $base_role_arn"
 
@@ -95,11 +100,14 @@ cat > "$base_policy_file" <<EOF
 EOF
 
 echo "Creating base role policy '$base_policy_name'..."
-base_policy_arn=$(aws iam create-policy \
-             --policy-name "$base_policy_name" \
-             --policy-document "file://$base_policy_file" \
-             --query Policy.Arn \
-             --output text)
+base_policy_arn="arn:aws:iam::${aws_account_id}:policy/${base_policy_name}"
+if ! aws iam get-policy --policy-arn "$base_policy_arn" >/dev/null 2>&1; then
+  base_policy_arn=$(aws iam create-policy \
+               --policy-name "$base_policy_name" \
+               --policy-document "file://$base_policy_file" \
+               --query Policy.Arn \
+               --output text)
+fi
 
 echo "Attaching policy to base role..."
 aws iam attach-role-policy \
@@ -130,11 +138,16 @@ cat > "$target_trust_file" <<EOF
 }
 EOF
 
-target_role_arn=$(aws iam create-role \
-             --role-name "$target_role_name" \
-             --assume-role-policy-document "file://$target_trust_file" \
-             --query Role.Arn \
-             --output text)
+if target_role_arn=$(aws iam get-role --role-name "$target_role_name" --query Role.Arn --output text 2>/dev/null); then
+  echo "Target role already exists, updating trust policy..."
+  aws iam update-assume-role-policy --role-name "$target_role_name" --policy-document "file://$target_trust_file"
+else
+  target_role_arn=$(aws iam create-role \
+               --role-name "$target_role_name" \
+               --assume-role-policy-document "file://$target_trust_file" \
+               --query Role.Arn \
+               --output text)
+fi
 
 echo "Target role created: $target_role_arn"
 
@@ -162,11 +175,14 @@ cat > "$target_policy_file" <<EOF
 EOF
 
 echo "Creating CloudWatch Logs policy '$target_policy_name'..."
-target_policy_arn=$(aws iam create-policy \
-             --policy-name "$target_policy_name" \
-             --policy-document "file://$target_policy_file" \
-             --query Policy.Arn \
-             --output text)
+target_policy_arn="arn:aws:iam::${aws_account_id}:policy/${target_policy_name}"
+if ! aws iam get-policy --policy-arn "$target_policy_arn" >/dev/null 2>&1; then
+  target_policy_arn=$(aws iam create-policy \
+               --policy-name "$target_policy_name" \
+               --policy-document "file://$target_policy_file" \
+               --query Policy.Arn \
+               --output text)
+fi
 
 echo "Attaching CloudWatch policy to target role..."
 aws iam attach-role-policy \
@@ -180,7 +196,8 @@ oc -n $namespace create secret generic aws-sts-cloudwatch \
   --from-literal=log_group_name="$log_group_name" \
   --from-literal=region="$region" \
   --from-literal=base_role_arn="$base_role_arn" \
-  --from-literal=target_role_arn="$target_role_arn"
+  --from-literal=target_role_arn="$target_role_arn" \
+  --dry-run=client -o yaml | oc apply -f -
 
 echo "AWS STS configuration for CloudWatch Logs completed successfully!"
 echo "Log Group: $log_group_name"

--- a/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/otel-collector-rolearn.yaml
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/otel-collector-rolearn.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otelcol-cloudwatch
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: otelcol-cloudwatch
   volumes:
     - name: aws-iam-token

--- a/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/otel-filelog-sidecar.yaml
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn-direct/otel-filelog-sidecar.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-logs-sidecar-rolearn-direct
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: sidecar
   config:
     receivers:

--- a/tests/e2e-otel/awscloudwatchlogs-rolearn/create-aws-rolearn-secret.sh
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn/create-aws-rolearn-secret.sh
@@ -63,11 +63,16 @@ cat > "$trust_rel_file" <<EOF
 EOF
 
 echo "Creating IAM role '$role_name'..."
-role_arn=$(aws iam create-role \
-             --role-name "$role_name" \
-             --assume-role-policy-document "file://$trust_rel_file" \
-             --query Role.Arn \
-             --output text)
+if role_arn=$(aws iam get-role --role-name "$role_name" --query Role.Arn --output text 2>/dev/null); then
+  echo "Role already exists, updating trust policy..."
+  aws iam update-assume-role-policy --role-name "$role_name" --policy-document "file://$trust_rel_file"
+else
+  role_arn=$(aws iam create-role \
+               --role-name "$role_name" \
+               --assume-role-policy-document "file://$trust_rel_file" \
+               --query Role.Arn \
+               --output text)
+fi
 
 # Create custom CloudWatch Logs policy
 policy_name="CloudWatchLogsPolicy-$namespace-$OPENSHIFT_BUILD_NAMESPACE"
@@ -93,11 +98,14 @@ cat > "$policy_file" <<EOF
 EOF
 
 echo "Creating IAM policy '$policy_name'..."
-policy_arn=$(aws iam create-policy \
-             --policy-name "$policy_name" \
-             --policy-document "file://$policy_file" \
-             --query Policy.Arn \
-             --output text)
+policy_arn="arn:aws:iam::${aws_account_id}:policy/${policy_name}"
+if ! aws iam get-policy --policy-arn "$policy_arn" >/dev/null 2>&1; then
+  policy_arn=$(aws iam create-policy \
+               --policy-name "$policy_name" \
+               --policy-document "file://$policy_file" \
+               --query Policy.Arn \
+               --output text)
+fi
 
 echo "Attaching policy '$policy_name' to role '$role_name'..."
 aws iam attach-role-policy \
@@ -110,7 +118,8 @@ echo "Create the secret to be used with OpenTelemetry Collector"
 oc -n $namespace create secret generic aws-sts-cloudwatch \
   --from-literal=log_group_name="$log_group_name" \
   --from-literal=region="$region" \
-  --from-literal=role_arn="$role_arn"
+  --from-literal=role_arn="$role_arn" \
+  --dry-run=client -o yaml | oc apply -f -
 
 echo "AWS STS configuration for CloudWatch Logs completed successfully!"
 echo "Log Group: $log_group_name"

--- a/tests/e2e-otel/awscloudwatchlogs-rolearn/otel-collector-rolearn.yaml
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn/otel-collector-rolearn.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otelcol-cloudwatch
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: otelcol-cloudwatch
   env:
     - name: AWS_REGION

--- a/tests/e2e-otel/awscloudwatchlogs-rolearn/otel-filelog-sidecar.yaml
+++ b/tests/e2e-otel/awscloudwatchlogs-rolearn/otel-filelog-sidecar.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otel-logs-sidecar-rolearn
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config:
     receivers:
       filelog:

--- a/tests/e2e-otel/awscloudwatchlogsexporter/otel-collector.yaml
+++ b/tests/e2e-otel/awscloudwatchlogsexporter/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: cwlogs
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   env:
     - name: AWS_ACCESS_KEY_ID
       valueFrom:

--- a/tests/e2e-otel/awscloudwatchlogsexporter/otel-filelog-sidecar.yaml
+++ b/tests/e2e-otel/awscloudwatchlogsexporter/otel-filelog-sidecar.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otel-logs-sidecar
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config:
     receivers:
       filelog:

--- a/tests/e2e-otel/awsxrayexporter/otel-collector.yaml
+++ b/tests/e2e-otel/awsxrayexporter/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: xray
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   env:
     - name: AWS_ACCESS_KEY_ID
       valueFrom:

--- a/tests/e2e-otel/azuremonitorlogs/README.md
+++ b/tests/e2e-otel/azuremonitorlogs/README.md
@@ -370,7 +370,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-logs-gateway
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   env:
     - name: AZURE_CLIENT_ID

--- a/tests/e2e-otel/azuremonitorlogs/otel-collector.yaml
+++ b/tests/e2e-otel/azuremonitorlogs/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-logs-gateway
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   env:
     - name: AZURE_CLIENT_ID

--- a/tests/e2e-otel/countconnector/otel-collector.yaml
+++ b/tests/e2e-otel/countconnector/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: count
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   observability:
     metrics:

--- a/tests/e2e-otel/filelog/otel-collector.yaml
+++ b/tests/e2e-otel/filelog/otel-collector.yaml
@@ -33,7 +33,7 @@ metadata:
   name: clusterlogs
   namespace: chainsaw-filelog
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: daemonset
   config:
     receivers:

--- a/tests/e2e-otel/filestorageext/otel-filestorageext.yaml
+++ b/tests/e2e-otel/filestorageext/otel-filestorageext.yaml
@@ -28,7 +28,7 @@ metadata:
   name: filestorageext-sidecar
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config: |
     receivers:
       filelog:

--- a/tests/e2e-otel/filterprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/filterprocessor/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: filterprocessor
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config:
     receivers:
       otlp:

--- a/tests/e2e-otel/forwardconnector/otel-forward-connector.yaml
+++ b/tests/e2e-otel/forwardconnector/otel-forward-connector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otlp-forward-connector
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config: |
     receivers:
       otlp/blue:

--- a/tests/e2e-otel/googlecloudexporter/otel-collector.yaml
+++ b/tests/e2e-otel/googlecloudexporter/otel-collector.yaml
@@ -34,7 +34,7 @@ metadata:
   name: googlecloudexporter
   namespace: chainsaw-googlecloudexporter
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-googlecloudexporter-sa
   # Mount the Google WIF credential file and expose the credential path as env var
   env:

--- a/tests/e2e-otel/googlemanagedprometheus/gcp-sa/metrics-generator-kubeletstats.yaml
+++ b/tests/e2e-otel/googlemanagedprometheus/gcp-sa/metrics-generator-kubeletstats.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: chainsaw-kubeletstatsreceiver
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-kubeletstatsreceiver
   env:
   - name: K8S_NODE_NAME

--- a/tests/e2e-otel/googlemanagedprometheus/gcp-wif/metrics-generator-kubeletstats.yaml
+++ b/tests/e2e-otel/googlemanagedprometheus/gcp-wif/metrics-generator-kubeletstats.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: chainsaw-kubeletstatsreceiver
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-kubeletstatsreceiver
   env:
   - name: K8S_NODE_NAME

--- a/tests/e2e-otel/groupbyattrsprocessor/check_metrics.sh
+++ b/tests/e2e-otel/groupbyattrsprocessor/check_metrics.sh
@@ -7,7 +7,7 @@ TOKEN=$(oc create token e2e-test-metrics-reader -n $NAMESPACE)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check metrics for OpenTelemetry collector instance.
-metrics="otelcol_processor_groupbyattrs_num_non_grouped_metrics_total otelcol_processor_groupbyattrs_metric_groups_bucket otelcol_processor_groupbyattrs_metric_groups_count otelcol_processor_groupbyattrs_metric_groups_sum"
+metrics="otelcol_processor_groupbyattrs_num_non_grouped_metrics otelcol_processor_groupbyattrs_metric_groups_bucket otelcol_processor_groupbyattrs_metric_groups_count otelcol_processor_groupbyattrs_metric_groups_sum"
 
 for metric in $metrics; do
 query="$metric"

--- a/tests/e2e-otel/groupbyattrsprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/otel-collector.yaml
@@ -39,7 +39,7 @@ metadata:
   namespace: chainsaw-gba
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-gba
   env:
   - name: K8S_NODE_IP

--- a/tests/e2e-otel/groupbyattrsprocessor/otel-groupbyattributes.yaml
+++ b/tests/e2e-otel/groupbyattrsprocessor/otel-groupbyattributes.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: chainsaw-gba
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   observability:
     metrics:
       enableMetrics: true

--- a/tests/e2e-otel/hostmetricsreceiver/otel-hostmetricsreceiver.yaml
+++ b/tests/e2e-otel/hostmetricsreceiver/otel-hostmetricsreceiver.yaml
@@ -44,7 +44,7 @@ metadata:
   name: otel-hstmtrs
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: otel-hostfs-daemonset
   config: |
     receivers:

--- a/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver.yaml
+++ b/tests/e2e-otel/k8sclusterreceiver/otel-k8sclusterreceiver.yaml
@@ -105,7 +105,7 @@ metadata:
   namespace: chainsaw-k8sclusterreceiver
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-k8sclusterreceiver
   config: |
     receivers:

--- a/tests/e2e-otel/k8seventsreceiver/otel-k8seventsreceiver.yaml
+++ b/tests/e2e-otel/k8seventsreceiver/otel-k8seventsreceiver.yaml
@@ -103,7 +103,7 @@ metadata:
   namespace: chainsaw-k8seventsreceiver
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-k8seventsreceiver
   config: |
     receivers:

--- a/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext.yaml
+++ b/tests/e2e-otel/k8sleaderelectorext/otel-k8sleaderelectorext.yaml
@@ -141,7 +141,7 @@ metadata:
 spec:
   mode: deployment
   replicas: 2
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-k8sleaderelectorext
   config: |
     extensions:

--- a/tests/e2e-otel/k8sobjectsreceiver/otel-k8sobjectsreceiver.yaml
+++ b/tests/e2e-otel/k8sobjectsreceiver/otel-k8sobjectsreceiver.yaml
@@ -56,7 +56,7 @@ metadata:
   namespace: chainsaw-k8sobjectsreceiver
 spec:
   mode: deployment
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-k8sobjectsreceiver
   config: |
     receivers:

--- a/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver.yaml
+++ b/tests/e2e-otel/kubeletstatsreceiver/otel-kubeletstatsreceiver.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: chainsaw-kubeletstatsreceiver
 spec:
   mode: daemonset
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-kubeletstatsreceiver
   env:
   - name: K8S_NODE_IP

--- a/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-lb.yaml
+++ b/tests/e2e-otel/loadbalancingexporter/otel-loadbalancingexporter-lb.yaml
@@ -50,7 +50,7 @@ metadata:
   name: chainsaw-lb
   namespace: chainsaw-lb
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   serviceAccount: chainsaw-lb
   config: |
     receivers:

--- a/tests/e2e-otel/oidcauthextension/install-otel-oidc-client.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-otel-oidc-client.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: chainsaw-oidc-client
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   volumes:
     - name: chainsaw-certs

--- a/tests/e2e-otel/oidcauthextension/install-otel-oidc-server.yaml
+++ b/tests/e2e-otel/oidcauthextension/install-otel-oidc-server.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: chainsaw-oidc-server
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   volumeMounts:
   - mountPath: /certs

--- a/tests/e2e-otel/otlpjsonfilereceiver/fileexporter-otel-collector.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/fileexporter-otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: fileexporter
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config: |
     receivers:
       otlp:

--- a/tests/e2e-otel/otlpjsonfilereceiver/otlpjsonfilereceiver-otel-collector.yaml
+++ b/tests/e2e-otel/otlpjsonfilereceiver/otlpjsonfilereceiver-otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otlpjsonfile
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config: |
     receivers:
       otlpjsonfile:

--- a/tests/e2e-otel/probabilisticsamplerprocessor/otel-collector-hash-seed.yaml
+++ b/tests/e2e-otel/probabilisticsamplerprocessor/otel-collector-hash-seed.yaml
@@ -4,7 +4,7 @@ metadata:
   name: probabilistic-hash-seed
   namespace: chainsaw-probabilistic-sampler
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   config:
     receivers:

--- a/tests/e2e-otel/probabilisticsamplerprocessor/otel-collector-proportional.yaml
+++ b/tests/e2e-otel/probabilisticsamplerprocessor/otel-collector-proportional.yaml
@@ -4,7 +4,7 @@ metadata:
   name: probabilistic-proportional
   namespace: chainsaw-probabilistic-sampler
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   config:
     receivers:

--- a/tests/e2e-otel/profilesignal/otel-collector.yaml
+++ b/tests/e2e-otel/profilesignal/otel-collector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: otel-profiles-collector
   namespace: chainsaw-profilesignal
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   args:
     feature-gates: service.profilesSupport

--- a/tests/e2e-otel/prometheusremotewriteexporter/otel-collector.yaml
+++ b/tests/e2e-otel/prometheusremotewriteexporter/otel-collector.yaml
@@ -20,7 +20,7 @@ spec:
     - name: certs-volume
       secret:
         secretName: prometheus-ca
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   config: |
     receivers:

--- a/tests/e2e-otel/prometheusremotewritereceiver/README.md
+++ b/tests/e2e-otel/prometheusremotewritereceiver/README.md
@@ -30,7 +30,7 @@ The test uses the following key resources that are included in this directory:
   - Receives metrics via OTLP from telemetrygen
   - Exports metrics to the receiver using Prometheus Remote Write v2
   - Enables RW v2 via feature gate and v2 protobuf message
-  - Uses the contrib collector image version `0.142.0`
+  - Uses the contrib collector image version `0.158.0`
 
 ### 3. Metrics Generator
 - **File**: [`generate-metrics.yaml`](./generate-metrics.yaml)
@@ -73,7 +73,7 @@ The test follows this sequence as defined in [`chainsaw-test.yaml`](./chainsaw-t
 ### Sender Collector Prometheus Remote Write (v2) Configuration:
 - **Target Endpoint**: `http://otel-receiver-collector:9090/api/v1/write`
 - **Protocol**: Prometheus Remote Write v2 (enabled via feature gate + v2 protobuf)
-- **Collector Image**: `opentelemetry-collector-contrib:0.148.0`
+- **Collector Image**: `opentelemetry-collector-contrib:0.158.0`
 
 ### Simplified Architecture:
 ```

--- a/tests/e2e-otel/prometheusremotewritereceiver/otel-collector-receiver.yaml
+++ b/tests/e2e-otel/prometheusremotewritereceiver/otel-collector-receiver.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-receiver
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   config: |
     receivers:

--- a/tests/e2e-otel/prometheusremotewritereceiver/otel-collector-sender.yaml
+++ b/tests/e2e-otel/prometheusremotewritereceiver/otel-collector-sender.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-sender
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   mode: deployment
   args:
     feature-gates: exporter.prometheusremotewritexporter.enableSendingRW2

--- a/tests/e2e-otel/routingconnector/otel-collector.yaml
+++ b/tests/e2e-otel/routingconnector/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: routing
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config:
     receivers:
       otlp:

--- a/tests/e2e-otel/tailsamplingprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/tailsamplingprocessor/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: tailsmp
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config:
     receivers:
       otlp:

--- a/tests/e2e-otel/transformprocessor/otel-collector.yaml
+++ b/tests/e2e-otel/transformprocessor/otel-collector.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: tprocssr
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.148.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.158.0
   config:
     receivers:
       otlp:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Upgraded OpenTelemetry Collector test images to version 0.158.0 across end-to-end scenarios.
  - Updated metric validation to use the current group-by-attributes metric name.
  - Improved AWS IAM test setup to reuse existing roles and policies, update trust settings, and apply secrets idempotently.
  - Improved repeatability and reliability of AWS integration test setup.

- **Documentation**
  - Updated documented Collector image versions to 0.158.0 in relevant test guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->